### PR TITLE
Add configuration option to disable accounting feature by default

### DIFF
--- a/TelegramSearchBot/Controller/Manage/AccountController.cs
+++ b/TelegramSearchBot/Controller/Manage/AccountController.cs
@@ -10,6 +10,7 @@ using TelegramSearchBot.Manager;
 using TelegramSearchBot.Model;
 using TelegramSearchBot.Service.BotAPI;
 using TelegramSearchBot.View;
+using TelegramSearchBot;
 
 namespace TelegramSearchBot.Controller.Manage {
     public class AccountController : IOnUpdate
@@ -35,6 +36,12 @@ namespace TelegramSearchBot.Controller.Manage {
 
         public async Task ExecuteAsync(PipelineContext p)
         {
+            // 检查账本功能是否启用
+            if (!Env.EnableAccounting)
+            {
+                return; // 功能未启用，直接返回
+            }
+
             var update = p.Update;
             await ExecuteAsync(update);
             if (update?.Message == null || update.Message.Chat.Id > 0)
@@ -134,6 +141,12 @@ namespace TelegramSearchBot.Controller.Manage {
 
         public async Task ExecuteAsync(Update update)
         {
+            // 检查账本功能是否启用
+            if (!Env.EnableAccounting)
+            {
+                return; // 功能未启用，直接返回
+            }
+
             if (update.CallbackQuery == null) return;
             
             var callbackQuery = update.CallbackQuery;

--- a/TelegramSearchBot/Env.cs
+++ b/TelegramSearchBot/Env.cs
@@ -31,6 +31,7 @@ namespace TelegramSearchBot {
                 OLTPAuthUrl = config.OLTPAuthUrl;
                 OLTPName = config.OLTPName;
                 BraveApiKey = config.BraveApiKey;
+                EnableAccounting = config.EnableAccounting;
             } catch { 
             }
             
@@ -56,6 +57,7 @@ namespace TelegramSearchBot {
         public static string OLTPAuthUrl { get; set; }
         public static string OLTPName { get; set; }
         public static string BraveApiKey { get; set; }
+        public static bool EnableAccounting { get; set; } = false;
 
         public static Dictionary<string, string> Configuration { get; set; } = new Dictionary<string, string>();
     }
@@ -77,5 +79,6 @@ namespace TelegramSearchBot {
         public string OLTPAuthUrl { get; set; }
         public string OLTPName { get; set; }
         public string BraveApiKey { get; set; }
+        public bool EnableAccounting { get; set; } = false;
     }
 }


### PR DESCRIPTION
## Summary
添加了一个配置选项，可以默认禁用账本功能。该功能默认为禁用状态，管理员可以通过配置文件启用。

## Changes Made
- **配置模型更新**: 在Config.cs中添加EnableAccounting属性，默认值为false
- **环境配置更新**: 在Env.cs中添加对应的静态属性和配置加载逻辑
- **功能检查**: 在AccountController中添加功能启用检查，禁用时忽略所有账本命令
- **默认安全性**: 功能默认禁用，避免不必要的资源消耗

## Key Features
- ✅ 默认禁用账本功能，提高安全性
- ✅ 通过配置文件控制功能启用/禁用
- ✅ 禁用状态下无数据库访问，零性能开销
- ✅ 启用时保持原有全部功能

## Test Plan
- [x] 验证功能禁用时所有账本命令被正确忽略
- [x] 验证功能启用时所有现有功能正常工作
- [x] 确认配置文件正确加载EnableAccounting属性
- [x] 测试默认值为false的正确性