### PR TITLE
Fix inverted index search by including MessageExtensions

### DIFF
--- a/TelegramSearchBot/Service/Storage/MessageService.cs
+++ b/TelegramSearchBot/Service/Storage/MessageService.cs
@@ -13,6 +13,7 @@ using MediatR;
 using TelegramSearchBot.Model.Data;
 using TelegramSearchBot.Model.Notifications;
 using TelegramSearchBot.Attributes;
+using Microsoft.EntityFrameworkCore;
 
 namespace TelegramSearchBot.Service.Storage
 {
@@ -38,7 +39,10 @@ namespace TelegramSearchBot.Service.Storage
 
         public async Task AddToLucene(MessageOption messageOption)
         {
-            var message = await DataContext.Messages.FindAsync(messageOption.MessageDataId);
+            var message = await DataContext.Messages
+                .Include(m => m.MessageExtensions)
+                .FirstOrDefaultAsync(m => m.Id == messageOption.MessageDataId);
+            
             if (message != null)
             {
                 await lucene.WriteDocumentAsync(message);


### PR DESCRIPTION
- Fix MessageService.AddToLucene() to eagerly load MessageExtensions
- Add Microsoft.EntityFrameworkCore import for Include() extension
- Ensure OCR/ASR text extensions are properly indexed in Lucene
- Resolve issue where extension data was not searchable

The bug was caused by FindAsync() only loading basic message data without extensions. Now OCR text (Ext_OCR_Result) and ASR transcripts (Ext_ASR_Result) are fully indexed and searchable through the inverted index.