### PR TITLE
修复扩展字段搜索逻辑问题

### DIFF
--- a/TelegramSearchBot/Manager/LuceneManager.cs
+++ b/TelegramSearchBot/Manager/LuceneManager.cs
@@ -180,8 +180,8 @@ namespace TelegramSearchBot.Manager
             var fields = MultiFields.GetIndexedFields(reader);
             foreach (var field in fields) {
                 if (field.StartsWith("Ext_")) {
-                    var terms = MultiFields.GetTerms(reader, field);
-                    if (terms != null) {
+                    // 检查searchTerms是否有内容，而不是检查字段中的术语
+                    if (searchTerms != null && searchTerms.Length > 0) {
                         var extQuery = new BooleanQuery();
                         foreach (var term in searchTerms) {
                             if (!string.IsNullOrWhiteSpace(term)) {

--- a/TelegramSearchBot/Service/Storage/MessageService.cs
+++ b/TelegramSearchBot/Service/Storage/MessageService.cs
@@ -13,6 +13,7 @@ using MediatR;
 using TelegramSearchBot.Model.Data;
 using TelegramSearchBot.Model.Notifications;
 using TelegramSearchBot.Attributes;
+using Microsoft.EntityFrameworkCore;
 
 namespace TelegramSearchBot.Service.Storage
 {
@@ -38,7 +39,10 @@ namespace TelegramSearchBot.Service.Storage
 
         public async Task AddToLucene(MessageOption messageOption)
         {
-            var message = await DataContext.Messages.FindAsync(messageOption.MessageDataId);
+            var message = await DataContext.Messages
+                .Include(m => m.MessageExtensions)
+                .FirstOrDefaultAsync(m => m.Id == messageOption.MessageDataId);
+            
             if (message != null)
             {
                 await lucene.WriteDocumentAsync(message);


### PR DESCRIPTION
## 问题描述
在调查搜索功能问题时，发现扩展字段搜索存在逻辑问题。虽然倒排索引的基础修复已经完成，但扩展字段搜索的条件检查逻辑不正确，导致在某些情况下扩展字段搜索可能被错误跳过。

## 修复内容
1. 修正了LuceneManager中扩展字段搜索的条件检查逻辑
2. 确保只有当searchTerms有内容时才添加扩展字段查询
3. 解决了扩展字段搜索可能被错误跳过的问题

## 测试验证
通过创建简单的Lucene测试程序验证了：
- 基本文本搜索功能正常工作
- 扩展字段索引和搜索功能正常工作
- 中文分词器正确处理了文本内容

## 相关问题
- 修复了扩展字段搜索逻辑问题
- 作为搜索功能整体优化的一部分

机器人生成：https://claude.ai/code