### PR TITLE
实现搜索功能分离：默认使用简单搜索，新增语法搜索命令

### DIFF
--- a/TelegramSearchBot/Controller/Search/SearchController.cs
+++ b/TelegramSearchBot/Controller/Search/SearchController.cs
@@ -45,6 +45,10 @@ namespace TelegramSearchBot.Controller.Search {
                 {
                     await HandleVectorSearch(e.Message);
                 }
+                else if (e.Message.Text.Length >= 7 && e.Message.Text.Substring(0, 6).Equals("语法搜索 "))
+                {
+                    await HandleSyntaxSearch(e.Message);
+                }
             }
         }
 
@@ -56,6 +60,11 @@ namespace TelegramSearchBot.Controller.Search {
         private async Task HandleVectorSearch(Message message)
         {
             await HandleSearchInternal(message, SearchType.Vector, 5);
+        }
+        
+        private async Task HandleSyntaxSearch(Message message)
+        {
+            await HandleSearchInternal(message, SearchType.SyntaxSearch, 6);
         }
 
         private async Task HandleSearchInternal(Message message, SearchType searchType, int prefixLength)

--- a/TelegramSearchBot/Controller/Search/SearchController.cs
+++ b/TelegramSearchBot/Controller/Search/SearchController.cs
@@ -45,7 +45,7 @@ namespace TelegramSearchBot.Controller.Search {
                 {
                     await HandleVectorSearch(e.Message);
                 }
-                else if (e.Message.Text.Length >= 7 && e.Message.Text.Substring(0, 6).Equals("语法搜索 "))
+                else if (e.Message.Text.Length >= 6 && e.Message.Text.Substring(0, 5).Equals("语法搜索 "))
                 {
                     await HandleSyntaxSearch(e.Message);
                 }
@@ -64,7 +64,7 @@ namespace TelegramSearchBot.Controller.Search {
         
         private async Task HandleSyntaxSearch(Message message)
         {
-            await HandleSearchInternal(message, SearchType.SyntaxSearch, 6);
+            await HandleSearchInternal(message, SearchType.SyntaxSearch, 5);
         }
 
         private async Task HandleSearchInternal(Message message, SearchType searchType, int prefixLength)
@@ -104,8 +104,21 @@ namespace TelegramSearchBot.Controller.Search {
             }
 
             // 添加切换搜索方式按钮
-            var alternativeSearchType = searchType == SearchType.InvertedIndex ? SearchType.Vector : SearchType.InvertedIndex;
-            var searchTypeText = alternativeSearchType == SearchType.Vector ? "向量搜索" : "倒排索引";
+            var alternativeSearchType = searchType switch
+            {
+                SearchType.InvertedIndex => SearchType.Vector,
+                SearchType.Vector => SearchType.SyntaxSearch,
+                SearchType.SyntaxSearch => SearchType.InvertedIndex,
+                _ => SearchType.InvertedIndex
+            };
+            
+            var searchTypeText = alternativeSearchType switch
+            {
+                SearchType.Vector => "向量搜索",
+                SearchType.SyntaxSearch => "语法搜索",
+                _ => "倒排索引"
+            };
+            
             var changeSearchTypeCallback = await callbackDataService.GenerateChangeSearchTypeCallbackAsync(searchOption, alternativeSearchType);
             searchView.AddButton($"切换到{searchTypeText}", changeSearchTypeCallback);
 

--- a/TelegramSearchBot/Model/SearchOption.cs
+++ b/TelegramSearchBot/Model/SearchOption.cs
@@ -15,7 +15,11 @@ namespace TelegramSearchBot.Model
         /// <summary>
         /// 向量搜索
         /// </summary>
-        Vector = 1
+        Vector = 1,
+        /// <summary>
+        /// 语法搜索（支持字段指定、排除词等语法）
+        /// </summary>
+        SyntaxSearch = 2
     }
 
     public class SearchOption {

--- a/TelegramSearchBot/View/SearchView.cs
+++ b/TelegramSearchBot/View/SearchView.cs
@@ -132,7 +132,7 @@ namespace TelegramSearchBot.View
         }
 
         private const string SearchResultTemplate = @"
-{{- search_type_text = search_option.search_type == 0 ? ""倒排索引"" : ""向量搜索"" -}}
+{{- search_type_text = search_option.search_type == 0 ? ""倒排索引"" : search_option.search_type == 1 ? ""向量搜索"" : ""语法搜索"" -}}
 <b>搜索方式</b>: {{search_type_text}}
 
 {{- if search_option.count > 0 -}}


### PR DESCRIPTION
## Summary
- 实现搜索功能分离：默认使用简单搜索，新增语法搜索命令
- 解决了之前倒排索引搜索的问题，用户现在可以根据需要选择不同的搜索方式

## Implementation details
1. 在LuceneManager中分离搜索实现：
   - SimpleSearch方法：简单搜索，只搜索Content字段，不支持语法
   - SyntaxSearch方法：保留当前实现，支持字段指定、排除词等语法
   - Search方法：默认调用简单搜索保持向后兼容

2. 在SearchService中添加对新搜索方法的支持：
   - 新增LuceneSyntaxSearch方法使用语法搜索实现
   - 修改Search方法根据SearchType决定使用哪种搜索方法

3. 在SearchOption中添加SyntaxSearch枚举值：
   - 添加SearchType.SyntaxSearch = 2

4. 在SearchController中添加语法搜索命令：
   - 新增"语法搜索 "命令，调用HandleSyntaxSearch方法
   - HandleSyntaxSearch方法使用SearchType.SyntaxSearch

## Test plan
- [x] 所有现有测试通过
- [x] 构建成功
- [ ] 验证默认搜索（"搜索 "命令）使用简单搜索
- [ ] 验证语法搜索（"语法搜索 "命令）使用支持语法的搜索实现

🤖 Generated with Claude Code