### PR TITLE
将MaxToolCycles修改为可定义的变量

### DIFF
--- a/TelegramSearchBot/Env.cs
+++ b/TelegramSearchBot/Env.cs
@@ -32,6 +32,7 @@ namespace TelegramSearchBot {
                 OLTPName = config.OLTPName;
                 BraveApiKey = config.BraveApiKey;
                 EnableAccounting = config.EnableAccounting;
+                MaxToolCycles = config.MaxToolCycles;
             } catch {
             }
 
@@ -58,6 +59,7 @@ namespace TelegramSearchBot {
         public static string OLTPName { get; set; }
         public static string BraveApiKey { get; set; }
         public static bool EnableAccounting { get; set; } = false;
+        public static int MaxToolCycles { get; set; }
 
         public static Dictionary<string, string> Configuration { get; set; } = new Dictionary<string, string>();
     }
@@ -80,5 +82,6 @@ namespace TelegramSearchBot {
         public string OLTPName { get; set; }
         public string BraveApiKey { get; set; }
         public bool EnableAccounting { get; set; } = false;
+        public int MaxToolCycles { get; set; } = 5;
     }
 }

--- a/TelegramSearchBot/Env.cs
+++ b/TelegramSearchBot/Env.cs
@@ -82,6 +82,6 @@ namespace TelegramSearchBot {
         public string OLTPName { get; set; }
         public string BraveApiKey { get; set; }
         public bool EnableAccounting { get; set; } = false;
-        public int MaxToolCycles { get; set; } = 5;
+        public int MaxToolCycles { get; set; } = 25;
     }
 }

--- a/TelegramSearchBot/Service/AI/LLM/GeminiService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/GeminiService.cs
@@ -268,7 +268,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
                 _chatSessions[ChatId] = chatSession;
             }
 
-            int maxToolCycles = 5;
+            int maxToolCycles = Env.MaxToolCycles;
             var currentMessageBuilder = new StringBuilder();
             for (int cycle = 0; cycle < maxToolCycles; cycle++) {
                 if (cancellationToken.IsCancellationRequested) throw new TaskCanceledException();

--- a/TelegramSearchBot/Service/AI/LLM/OllamaService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/OllamaService.cs
@@ -121,7 +121,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
             try {
                 string nextMessageToSend = message.Content;
-                int maxToolCycles = 5;
+                int maxToolCycles = Env.MaxToolCycles;
                 var currentLlmResponseBuilder = new StringBuilder(); // Accumulates tokens for the current LLM response
 
                 for (int cycle = 0; cycle < maxToolCycles; cycle++) {

--- a/TelegramSearchBot/Service/AI/LLM/OpenAIService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/OpenAIService.cs
@@ -589,7 +589,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             var chatClient = new ChatClient(model: modelName, credential: new(channel.ApiKey), clientOptions);
 
             try {
-                int maxToolCycles = 5;
+                int maxToolCycles = Env.MaxToolCycles;
                 var currentMessageContentBuilder = new StringBuilder(); // Used to build the current full message for yielding
 
                 for (int cycle = 0; cycle < maxToolCycles; cycle++) {


### PR DESCRIPTION
This pull request introduces a configurable limit for the number of tool cycles used in AI service classes, replacing the previous hardcoded value. The new configuration option is added to the environment settings and propagated to the relevant service implementations, allowing for easier adjustment and centralized control.

Configuration enhancements:

* Added `MaxToolCycles` property to the `Config` class with a default value of 25, and exposed it in the `Env` class for global access. [[1]](diffhunk://#diff-165dfff2c3ee3b2364484ae765d9533e583154f40e3ecfd928553bfea00c3eb9R35) [[2]](diffhunk://#diff-165dfff2c3ee3b2364484ae765d9533e583154f40e3ecfd928553bfea00c3eb9R62) [[3]](diffhunk://#diff-165dfff2c3ee3b2364484ae765d9533e583154f40e3ecfd928553bfea00c3eb9R85)

AI service updates:

* Replaced the hardcoded `maxToolCycles` value in `GeminiService`, `OllamaService`, and `OpenAIService` with the new `Env.MaxToolCycles` configuration, ensuring consistent behavior across services. [[1]](diffhunk://#diff-8595a61be43bd0f1fb33b43971e2dac333d29e7de954a8072b1754a0be771454L271-R271) [[2]](diffhunk://#diff-f0fa4ae51878e94eac31c8f3cfc5ae69f0eefc583d6d3e94fe218783b96ad8e6L124-R124) [[3]](diffhunk://#diff-9c1393e3093e6fbc9f802c3ad70c176c59952708140dcdd4679521eb8b5cddb4L592-R592)