### PR TITLE
feat: 添加搜索页面缓存清理任务到可用任务列表，并调整首次执行基准时间

### DIFF
--- a/TelegramSearchBot/Controller/Manage/ScheduledTaskController.cs
+++ b/TelegramSearchBot/Controller/Manage/ScheduledTaskController.cs
@@ -83,7 +83,8 @@ namespace TelegramSearchBot.Controller.Manage {
 • `/scheduler history` - 查看任务执行历史
 
 可用任务：
-• WordCloudReport - 词云报告任务";
+• WordCloudReport - 词云报告任务
+• SearchPageCacheCleanup - 搜索页面缓存清理任务";
 
             await _sendMessage.AddTask(async () => {
                 await _botClient.SendMessage(

--- a/TelegramSearchBot/Service/Scheduler/SchedulerService.cs
+++ b/TelegramSearchBot/Service/Scheduler/SchedulerService.cs
@@ -143,8 +143,11 @@ namespace TelegramSearchBot.Service.Scheduler {
                 // 确定上次执行的基准时间
                 DateTime lastRunTime;
                 if (lastExecution == null) {
-                    // 如果从未执行过，使用当前UTC时间作为基准
-                    lastRunTime = DateTime.UtcNow;
+                    // 如果从未执行过，使用稍早于当前时间的基准，避免首次执行被跳过
+                    var baselineOffset = _checkInterval > TimeSpan.Zero
+                        ? _checkInterval
+                        : TimeSpan.FromMinutes(1);
+                    lastRunTime = DateTime.UtcNow - baselineOffset;
                 } else if (lastExecution.CompletedTime.HasValue) {
                     // 如果有完成时间，使用完成时间作为基准
                     // 从数据库读取的时间 Kind 可能是 Unspecified，需要指定为 Utc


### PR DESCRIPTION
这个 pull 请求为 Telegram 机器人中的计划任务管理功能引入了改进，具体增强了任务可见性和执行逻辑。主要变化包括更新帮助信息以列出所有可用任务，并优化确定计划任务何时运行的逻辑，确保新任务在首次检查时不会被遗漏。

**计划器帮助信息改进：**

* 更新了`ScheduledTaskController.cs`中的`/scheduler history`帮助信息，将`SearchPageCacheCleanup`作为可用任务列出，使用户更清楚哪些任务可以管理。

**任务执行逻辑增强：**

* 改进了 `SchedulerService.cs` 中计划任务的基线计算，以便如果任务从未被执行过，其第一个符合条件的运行时间会设置在当前时间稍早（使用检查间隔或默认一分钟）。这可以防止新任务在初次执行检查时被跳过。