### PR TITLE
Add admin permission check to ScheduledTaskController

### DIFF
--- a/TelegramSearchBot/Controller/Manage/ScheduledTaskController.cs
+++ b/TelegramSearchBot/Controller/Manage/ScheduledTaskController.cs
@@ -17,8 +17,8 @@ namespace TelegramSearchBot.Controller.Manage {
         private readonly ITelegramBotClient _botClient;
         private readonly SendMessage _sendMessage;
         private readonly DataDbContext _dbContext;
-    private readonly ISchedulerService _schedulerService;
-    private readonly AdminService _adminService;
+        private readonly ISchedulerService _schedulerService;
+        private readonly AdminService _adminService;
 
         public List<Type> Dependencies => new List<Type>();
 


### PR DESCRIPTION
这个拉取请求通过在允许用户执行调度相关命令之前引入管理员检查，增强了计划任务管理功能的安全性。主要更改涉及集成`AdminService`并更新命令处理逻辑，以限制只有管理员才能访问。

### 安全性和访问控制

* 在`ScheduledTaskController`中添加了对`AdminService`的依赖，以启用管理员权限检查。（`TelegramSearchBot/Controller/Manage/ScheduledTaskController.cs`）[[1]](diffhunk://#diff-0f45911cfa12a1a6069d1264386adeb1e2bd26754e707a316657f859723502b2R11) [[2]](diffhunk://#diff-0f45911cfa12a1a6069d1264386adeb1e2bd26754e707a316657f859723502b2R21-R35)
* 更新了`/scheduler`命令处理程序，以使用`AdminService.IsNormalAdmin`验证用户是否为普通管理员。如果用户缺乏管理员权限，将发送权限错误消息，并且不会执行该命令。（`TelegramSearchBot/Controller/Manage/ScheduledTaskController.cs`）