### PR TITLE
fix: use bun add -g opencode-ai

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install OpenCode and oh-my-opencode
         run: |
-          npm install -g @opencode-ai/cli
+          bun add -g opencode-ai
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
 
       - name: Copy oh-my-opencode config
@@ -69,7 +69,7 @@ jobs:
         env:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
-          npm install -g @opencode-ai/cli
+          bun add -g opencode-ai
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
           
           node -e "
@@ -115,7 +115,7 @@ jobs:
         env:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
-          npm install -g @opencode-ai/cli
+          bun add -g opencode-ai
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
           
           node -e "

--- a/.github/workflows/ai-iterate.yml
+++ b/.github/workflows/ai-iterate.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Install OpenCode and oh-my-opencode
         run: |
-          npm install -g @opencode-ai/cli
+          bun add -g opencode-ai
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
 
       - name: Copy oh-my-opencode config
@@ -69,7 +69,7 @@ jobs:
         env:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
-          npm install -g @opencode-ai/cli
+          bun add -g opencode-ai
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
 
           node -e "const fs=require('fs');const c=JSON.parse(process.env.COMMENTS_DATA);let p=fs.readFileSync('.github/workflows/prompts/ai-iterate-prompt.txt','utf8');p=p.replace(/{{issue_number}}/g,'%ISSUE_NUM%').replace(/{{pr_number}}/g,'%PR_NUMBER%').replace(/{{comments}}/g,c.join('\n\n'));fs.writeFileSync('prompt.txt',p);"

--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Install OpenCode and oh-my-opencode
         run: |
-          npm install -g @opencode-ai/cli
+          bun add -g opencode-ai
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
 
       - name: Copy oh-my-opencode config
@@ -87,7 +87,7 @@ jobs:
           ISSUE_DATA: ${{ steps.issue.outputs.result }}
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
-          npm install -g @opencode-ai/cli
+          bun add -g opencode-ai
 
           node -e "
             const fs=require('fs');


### PR DESCRIPTION
Fix OpenCode installation command in AI workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to use bun for package management in deployment workflows, replacing the previous npm-based installation approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->