### PR TITLE
fix: enable MiniMax via --opencode-go

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install OpenCode and oh-my-opencode
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
+          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --opencode-go=yes
 
       - name: Copy oh-my-opencode config
         run: |
@@ -70,7 +70,7 @@ jobs:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
+          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --opencode-go=yes
           
           node -e "
             const fs = require('fs');
@@ -82,7 +82,7 @@ jobs:
             fs.writeFileSync('prompt.txt', p);
           "
           
-          cat prompt.txt | opencode run . --output result.txt
+          cat prompt.txt | opencode run --dir .
 
       - name: Check changes
         id: changes
@@ -116,7 +116,7 @@ jobs:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
+          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --opencode-go=yes
           
           node -e "
             const fs = require('fs');
@@ -125,7 +125,7 @@ jobs:
             fs.writeFileSync('fix_prompt.txt', p);
           "
           
-          cat fix_prompt.txt | opencode run . --output fix.txt
+          cat fix_prompt.txt | opencode run --dir .
           dotnet build TelegramSearchBot.sln --configuration Release
           dotnet test TelegramSearchBot.sln --configuration Release --no-build 2>nul || exit 0
 

--- a/.github/workflows/ai-iterate.yml
+++ b/.github/workflows/ai-iterate.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install OpenCode and oh-my-opencode
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
+          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --opencode-go=yes
 
       - name: Copy oh-my-opencode config
         run: |
@@ -70,11 +70,11 @@ jobs:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
+          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --opencode-go=yes
 
           node -e "const fs=require('fs');const c=JSON.parse(process.env.COMMENTS_DATA);let p=fs.readFileSync('.github/workflows/prompts/ai-iterate-prompt.txt','utf8');p=p.replace(/{{issue_number}}/g,'%ISSUE_NUM%').replace(/{{pr_number}}/g,'%PR_NUMBER%').replace(/{{comments}}/g,c.join('\n\n'));fs.writeFileSync('prompt.txt',p);"
 
-          cat prompt.txt | opencode run . --output result.txt
+          cat prompt.txt | opencode run --dir .
 
       - name: Check changes
         id: changes

--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install OpenCode and oh-my-opencode
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
+          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no --opencode-go=yes
 
       - name: Copy oh-my-opencode config
         run: |
@@ -97,11 +97,11 @@ jobs:
             p=p.replace(/{{issue_number}}/g,d.number)
                .replace(/{{issue_title}}/g,d.title)
                .replace(/{{issue_body}}/g,d.body)
-               .replace(/{{issue_url}}/g,d.url);
+                .replace(/{{issue_url}}/g,d.url);
             fs.writeFileSync('prompt.txt',p);
           "
 
-          cat prompt.txt | opencode run . --output plan.md
+          opencode run --dir . <<< "$(cat prompt.txt)"
 
       - name: Post plan comment
         if: steps.opencode.outputs.result != '' && steps.find-comment.outputs.result == 'none'


### PR DESCRIPTION
Enable OpenCode Go for MiniMax M2.5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development workflows to enable Go support.
  * Streamlined workflow commands for improved efficiency and simplified command execution patterns across automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->