### PR TITLE
fix: correct MiniMax API address (remove /v1)

### DIFF
--- a/.github/workflows/oh-my-opencode.json
+++ b/.github/workflows/oh-my-opencode.json
@@ -4,7 +4,7 @@
     "minimax": {
       "npm": "@ai-sdk/anthropic",
       "options": {
-        "baseURL": "https://api.minimaxi.com/anthropic/v1",
+        "baseURL": "https://api.minimaxi.com/anthropic",
         "apiKey": "MINIMAX_API_KEY"
       },
       "models": {


### PR DESCRIPTION
## Summary
- Correct MiniMax API address:  (without /v1 suffix)
- User confirmed this is the correct domestic API address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated API endpoint configuration to streamline service routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->