### PR TITLE
fix: correct PowerShell variable syntax for API key substitution

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -74,7 +74,7 @@ jobs:
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no 
           
           # 确保配置文件中的占位符被正确替换
-          powershell -Command "$content = Get-Content '.github/workflows/oh-my-opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', '%MINIMAX_API_KEY%'; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\oh-my-opencode.json -Value $content"
+          powershell -Command "$content = Get-Content '.github/workflows/oh-my-opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', $env:MINIMAX_API_KEY; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\oh-my-opencode.json -Value $content"
           
           node -e "
             const fs = require('fs');
@@ -123,7 +123,7 @@ jobs:
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no 
           
           # 确保配置文件中的占位符被正确替换
-          powershell -Command "$content = Get-Content '.github/workflows/oh-my-opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', '%MINIMAX_API_KEY%'; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\oh-my-opencode.json -Value $content"
+          powershell -Command "$content = Get-Content '.github/workflows/oh-my-opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', $env:MINIMAX_API_KEY; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\oh-my-opencode.json -Value $content"
           
           node -e "
             const fs = require('fs');

--- a/.github/workflows/ai-iterate.yml
+++ b/.github/workflows/ai-iterate.yml
@@ -74,7 +74,7 @@ jobs:
           bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no 
           
           # 替换配置文件中的占位符
-          powershell -Command "$content = Get-Content '.github/workflows/oh-my-opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', '%MINIMAX_API_KEY%'; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\oh-my-opencode.json -Value $content"
+          powershell -Command "$content = Get-Content '.github/workflows/oh-my-opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', $env:MINIMAX_API_KEY; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\oh-my-opencode.json -Value $content"
 
           node -e "const fs=require('fs');const c=JSON.parse(process.env.COMMENTS_DATA);let p=fs.readFileSync('.github/workflows/prompts/ai-iterate-prompt.txt','utf8');p=p.replace(/{{issue_number}}/g,'%ISSUE_NUM%').replace(/{{pr_number}}/g,'%PR_NUMBER%').replace(/{{comments}}/g,c.join('\n\n'));fs.writeFileSync('prompt.txt',p);"
 


### PR DESCRIPTION
## Summary
- Change %MINIMAX_API_KEY% to :MINIMAX_API_KEY in PowerShell commands
- This was a critical bug preventing API key from being properly substituted