### PR TITLE
fix: Windows PowerShell syntax and MiniMax config

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -42,7 +42,10 @@ jobs:
       - name: Extract issue number
         id: extract
         run: |
-          for /f "tokens=2 delims=/" %%a in ("%GITHUB_REF_NAME%") do echo issue_number=%%a >> %GITHUB_OUTPUT%
+          $ref = $env:GITHUB_REF_NAME
+          if ($ref -match 'ai/issue-(\d+)') {
+            Write-Output "issue_number=$($Matches[1])" >> $env:GITHUB_OUTPUT
+          }
 
       - name: Set environment variables
         run: |
@@ -76,9 +79,11 @@ jobs:
           ISSUE_DATA: ${{ steps.issue.outputs.result }}
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no 
           
-          # 确保配置文件中的占位符被正确替换
+          # 复制并替换 opencode.json (本体配置)
+          powershell -Command "$content = Get-Content '.github/workflows/opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', $env:MINIMAX_API_KEY; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\opencode.json -Value $content"
+          
+          # 复制并替换 oh-my-opencode.json (插件配置)
           powershell -Command "$content = Get-Content '.github/workflows/oh-my-opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', $env:MINIMAX_API_KEY; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\oh-my-opencode.json -Value $content"
           
           node -e "

--- a/.github/workflows/ai-iterate.yml
+++ b/.github/workflows/ai-iterate.yml
@@ -42,8 +42,11 @@ jobs:
       - name: Extract issue number
         id: extract
         run: |
-          for /f "tokens=2 delims=/" %%a in ("%GITHUB_HEAD_REF%") do echo issue_number=%%a >> %GITHUB_OUTPUT%
-          echo pr_number=%GITHUB_PR_NUMBER% >> %GITHUB_OUTPUT%
+          $branch = $env:GITHUB_HEAD_REF
+          if ($branch -match 'ai/issue-(\d+)') {
+            Write-Output "issue_number=$($Matches[1])" >> $env:GITHUB_OUTPUT
+          }
+          Write-Output "pr_number=$env:GITHUB_PR_NUMBER" >> $env:GITHUB_OUTPUT
 
       - name: Set environment variables
         run: |
@@ -76,9 +79,11 @@ jobs:
           COMMENTS_DATA: ${{ steps.comments.outputs.result }}
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no 
           
-          # 替换配置文件中的占位符
+          # 复制并替换 opencode.json (本体配置)
+          powershell -Command "$content = Get-Content '.github/workflows/opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', $env:MINIMAX_API_KEY; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\opencode.json -Value $content"
+          
+          # 复制并替换 oh-my-opencode.json (插件配置)
           powershell -Command "$content = Get-Content '.github/workflows/oh-my-opencode.json' -Raw; $content = $content -replace 'MINIMAX_API_KEY', $env:MINIMAX_API_KEY; Set-Content -Path $env:USERPROFILE\\.config\\opencode\\oh-my-opencode.json -Value $content"
 
           node -e "const fs=require('fs');const c=JSON.parse(process.env.COMMENTS_DATA);let p=fs.readFileSync('.github/workflows/prompts/ai-iterate-prompt.txt','utf8');p=p.replace(/{{issue_number}}/g,'$env:ISSUE_NUM').replace(/{{pr_number}}/g,'$env:PR_NUMBER').replace(/{{comments}}/g,c.join('\n\n'));fs.writeFileSync('prompt.txt',p);"

--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -27,12 +27,16 @@ jobs:
       - name: Install OpenCode and oh-my-opencode
         run: |
           bun add -g opencode-ai
-          bunx oh-my-opencode install --no-tui --claude=no --gemini=no --copilot=no
 
-      - name: Copy oh-my-opencode config
+      - name: Copy configs and setup
+        env:
+          MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
         run: |
           mkdir -p ~/.config/opencode
-          cp .github/workflows/oh-my-opencode.json ~/.config/opencode/oh-my-opencode.json
+          # 复制并替换 opencode.json (本体配置)
+          sed "s/MINIMAX_API_KEY/${MINIMAX_API_KEY}/g" .github/workflows/opencode.json > ~/.config/opencode/opencode.json
+          # 复制并替换 oh-my-opencode.json (插件配置)
+          sed "s/MINIMAX_API_KEY/${MINIMAX_API_KEY}/g" .github/workflows/oh-my-opencode.json > ~/.config/opencode/oh-my-opencode.json
 
       - name: Get issue details
         id: issue


### PR DESCRIPTION
## Summary
1. Fix PowerShell syntax in Windows runners (for/%%a -> regex)
2. Add opencode.json config copying for MiniMax provider
3. Fix API key substitution in all workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflow configurations for improved automation reliability and configuration handling.

**Note:** This release contains internal infrastructure updates with no direct user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->