### PR TITLE
fix: ai-plan workflow - add opencode.json copy and fix sed syntax

### DIFF
--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -95,7 +95,8 @@ jobs:
           bun add -g opencode-ai
           
           # 确保配置文件中的占位符被正确替换
-          sed 's/MINIMAX_API_KEY/'"$MINIMAX_API_KEY"'/g' .github/workflows/oh-my-opencode.json > ~/.config/opencode/oh-my-opencode.json
+          sed "s/MINIMAX_API_KEY/${MINIMAX_API_KEY}/g" .github/workflows/opencode.json > ~/.config/opencode/opencode.json
+          sed "s/MINIMAX_API_KEY/${MINIMAX_API_KEY}/g" .github/workflows/oh-my-opencode.json > ~/.config/opencode/oh-my-opencode.json
 
           node -e "
             const fs=require('fs');


### PR DESCRIPTION
## Summary
- Add opencode.json copy to Generate plan step
- Fix sed syntax for variable substitution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration handling to process multiple configuration files simultaneously during automated setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->