### PR TITLE
fix: add apiKey to opencode.json provider config

### DIFF
--- a/.github/workflows/opencode.json
+++ b/.github/workflows/opencode.json
@@ -3,6 +3,7 @@
   "provider": {
     "minimax": {
       "api": "https://api.minimaxi.com/v1",
+      "apiKey": "MINIMAX_API_KEY",
       "model": "MiniMax-M2.5"
     }
   }


### PR DESCRIPTION
## Summary
- Add apiKey field to opencode.json provider configuration