### PR TITLE
fix(ai-workflow): Fix opencode run command syntax

### DIFF
--- a/.github/workflows/ai-implement.yml
+++ b/.github/workflows/ai-implement.yml
@@ -95,7 +95,8 @@ jobs:
             fs.writeFileSync(tempPath, p);
           "
           
-          opencode . < %TEMP%\prompt.txt --opencode-go=yes
+          # 运行 opencode
+          opencode run "$(type %TEMP%\prompt.txt)"
 
       - name: Check changes
         id: changes

--- a/.github/workflows/ai-iterate.yml
+++ b/.github/workflows/ai-iterate.yml
@@ -86,7 +86,8 @@ jobs:
           # 创建临时 prompt 文件在 TEMP 目录
           node -e "const fs=require('fs');const c=JSON.parse(process.env.COMMENTS_DATA);let p=fs.readFileSync('.github/workflows/prompts/ai-iterate-prompt.txt','utf8');p=p.replace(/{{issue_number}}/g,'$env:ISSUE_NUM').replace(/{{pr_number}}/g,'$env:PR_NUMBER').replace(/{{comments}}/g,c.join('\\n\\n'));fs.writeFileSync(process.env.TEMP + '\\\\prompt.txt',p);"
 
-          opencode . < %TEMP%\prompt.txt --opencode-go=yes
+          # 运行 opencode
+          opencode run "$(type %TEMP%\prompt.txt)"
 
       - name: Check changes
         id: changes

--- a/.github/workflows/ai-plan.yml
+++ b/.github/workflows/ai-plan.yml
@@ -105,7 +105,7 @@ jobs:
           "
 
           # 运行 opencode
-          opencode . < /tmp/prompt.txt --opencode-go=yes
+          opencode run "$(cat /tmp/prompt.txt)"
 
       - name: Post plan comment
         if: steps.find-comment.outputs.result == 'none'


### PR DESCRIPTION
## Summary
- Fix opencode command syntax: use 'opencode run' instead of 'opencode . < prompt.txt --opencode-go=yes'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD workflow configurations to refine how automated code generation processes are invoked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->