### PR TITLE
fix(ai-workflow): Add default model to opencode.json

### DIFF
--- a/.github/workflows/opencode.json
+++ b/.github/workflows/opencode.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://opencode.ai/config.json",
+  "model": "minimax/MiniMax-M2.5",
   "provider": {
     "minimax": {
       "npm": "@ai-sdk/anthropic",


### PR DESCRIPTION
## Summary
- Add default model setting to use MiniMax-M2.5 (not highspeed)