### PR TITLE
fix: add /v1 suffix to MiniMax API endpoint

### DIFF
--- a/.github/workflows/oh-my-opencode.json
+++ b/.github/workflows/oh-my-opencode.json
@@ -4,7 +4,7 @@
     "minimax": {
       "npm": "@ai-sdk/anthropic",
       "options": {
-        "baseURL": "https://api.minimaxi.com/anthropic",
+        "baseURL": "https://api.minimaxi.com/anthropic/v1",
         "apiKey": "MINIMAX_API_KEY"
       },
       "models": {

--- a/.github/workflows/opencode.json
+++ b/.github/workflows/opencode.json
@@ -5,7 +5,7 @@
     "minimax": {
       "npm": "@ai-sdk/anthropic",
       "options": {
-        "baseURL": "https://api.minimaxi.com/anthropic",
+        "baseURL": "https://api.minimaxi.com/anthropic/v1",
         "apiKey": "MINIMAX_API_KEY"
       },
       "models": {


### PR DESCRIPTION
## Summary\n- Fix MiniMax API endpoint: add /v1 suffix to baseURL\n- This fixes the 404 Not Found error when calling MiniMax API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimax API endpoint configuration to version 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->