### PR TITLE
feat(LLM): show tool call parameters in display message

### DIFF
--- a/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
@@ -581,9 +581,19 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
                     trackedHistory.Add(new SerializedChatMessage { Role = "assistant", Content = responseText });
 
-                    // Show tool call indicators
-                    var toolNames = string.Join(", ", toolUseBlocks.Select(t => $"`{t.name}`"));
-                    currentMessageContentBuilder.Append($"\n\n🔧 {toolNames}\n\n");
+                    var toolNamesBuilder = new StringBuilder();
+                    foreach (var (id, name, inputJson) in toolUseBlocks) {
+                        Dictionary<string, string> argsDict = null;
+                        if (!string.IsNullOrWhiteSpace(inputJson)) {
+                            try {
+                                argsDict = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, JsonElement>>(inputJson)
+                                    .ToDictionary(kv => kv.Key, kv => kv.Value.ToString());
+                            } catch { }
+                        }
+                        argsDict ??= new Dictionary<string, string>();
+                        toolNamesBuilder.Append(McpToolHelper.FormatToolCallDisplay(name, argsDict));
+                    }
+                    currentMessageContentBuilder.Append(toolNamesBuilder.ToString());
                     yield return currentMessageContentBuilder.ToString();
 
                     // Execute tools and build tool result message
@@ -715,7 +725,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
                         _logger.LogWarning("{ServiceName}: LLM returned multiple tool calls ({Count}). Only the first one ('{FirstToolName}') will be executed.", ServiceName, parsedToolCalls.Count, parsedToolName);
                     }
 
-                    currentMessageContentBuilder.Append($"\n\n🔧 `{parsedToolName}`\n\n");
+                    currentMessageContentBuilder.Append(McpToolHelper.FormatToolCallDisplay(parsedToolName, toolArguments));
                     yield return currentMessageContentBuilder.ToString();
 
                     string toolResultString;
@@ -845,7 +855,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
                     _logger.LogInformation("{ServiceName}: LLM requested tool (resume): {ToolName}", ServiceName, parsedToolName);
 
-                    var toolIndicator = $"\n\n🔧 `{parsedToolName}`\n\n";
+                    var toolIndicator = McpToolHelper.FormatToolCallDisplay(parsedToolName, firstToolCall.arguments);
                     newContentBuilder.Append(toolIndicator);
                     fullContentBuilder.Append(toolIndicator);
                     yield return newContentBuilder.ToString();

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
@@ -393,8 +393,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
                         firstToolCall.toolName,
                         JsonConvert.SerializeObject(firstToolCall.arguments));
 
-                    // Add tool call indicator to output
-                    currentMessageBuilder.Append($"\n\n🔧 `{firstToolCall.toolName}`\n\n");
+                    currentMessageBuilder.Append(McpToolHelper.FormatToolCallDisplay(firstToolCall.toolName, firstToolCall.arguments));
                     yield return currentMessageBuilder.ToString();
 
                     string toolResult;

--- a/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
@@ -811,6 +811,33 @@ namespace TelegramSearchBot.Service.AI.LLM {
                 }
             }
         }
+
+        private const int MaxToolParamDisplayLength = 100;
+
+        /// <summary>
+        /// Formats tool call information for display to user, including tool name and a summary of parameters.
+        /// Long parameter values are truncated to MaxToolParamDisplayLength characters.
+        /// </summary>
+        /// <param name="toolName">The name of the tool being called</param>
+        /// <param name="arguments">Dictionary of tool arguments</param>
+        /// <returns>A formatted string like "🔧 `tool_name` [param1: value1, param2: value2...]"</returns>
+        public static string FormatToolCallDisplay(string toolName, Dictionary<string, string> arguments) {
+            if (arguments == null || !arguments.Any()) {
+                return $"\n\n🔧 `{toolName}`\n\n";
+            }
+
+            var paramSummaries = new List<string>();
+            foreach (var kvp in arguments) {
+                string value = kvp.Value ?? "null";
+                if (value.Length > MaxToolParamDisplayLength) {
+                    value = value.Substring(0, MaxToolParamDisplayLength) + "...";
+                }
+                value = value.Replace("\n", " ").Replace("\r", " ");
+                paramSummaries.Add($"{kvp.Key}: {value}");
+            }
+
+            return $"\n\n🔧 `{toolName}` [{string.Join(", ", paramSummaries)}]\n\n";
+        }
         /// <summary>
         /// Register external MCP tools from connected MCP servers.
         /// These tools are added to the system prompt and routed to the MCP server for execution.

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OllamaService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OllamaService.cs
@@ -171,8 +171,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
                             _logger.LogWarning("{ServiceName}: LLM returned multiple tool calls ({Count}). Only the first one ('{FirstToolName}') will be executed.", ServiceName, parsedToolCalls.Count, parsedToolName);
                         }
 
-                        // Add tool call indicator to output
-                        currentLlmResponseBuilder.Append($"\n\n🔧 `{parsedToolName}`\n\n");
+                        currentLlmResponseBuilder.Append(McpToolHelper.FormatToolCallDisplay(parsedToolName, toolArguments));
                         yield return currentLlmResponseBuilder.ToString();
 
                         string toolResultString;

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
@@ -1027,9 +1027,14 @@ namespace TelegramSearchBot.Service.AI.LLM {
                         }
                         providerHistory.Add(assistantMessage);
 
-                        // Add tool call indicator to output
-                        var toolNames = string.Join(", ", chatToolCalls.Select(tc => $"`{tc.FunctionName}`"));
-                        currentMessageContentBuilder.Append($"\n\n🔧 {toolNames}\n\n");
+                        var toolIndicators = new StringBuilder();
+                        foreach (var toolCall in chatToolCalls) {
+                            var argsJson = toolCall.FunctionArguments?.ToString() ?? "{}";
+                            var argsDict = JsonConvert.DeserializeObject<Dictionary<string, string>>(argsJson)
+                                ?? new Dictionary<string, string>();
+                            toolIndicators.Append(McpToolHelper.FormatToolCallDisplay(toolCall.FunctionName, argsDict));
+                        }
+                        currentMessageContentBuilder.Append(toolIndicators.ToString());
                         yield return currentMessageContentBuilder.ToString();
 
                         // Execute each tool call
@@ -1150,8 +1155,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
                             _logger.LogWarning("{ServiceName}: LLM returned multiple tool calls ({Count}). Only the first one ('{FirstToolName}') will be executed.", ServiceName, parsedToolCalls.Count, parsedToolName);
                         }
 
-                        // Add tool call indicator to output
-                        currentMessageContentBuilder.Append($"\n\n🔧 `{parsedToolName}`\n\n");
+                        currentMessageContentBuilder.Append(McpToolHelper.FormatToolCallDisplay(parsedToolName, toolArguments));
                         yield return currentMessageContentBuilder.ToString();
 
                         string toolResultString;
@@ -1271,8 +1275,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
                         _logger.LogInformation("{ServiceName}: LLM requested tool (resume): {ToolName}", ServiceName, parsedToolName);
 
-                        // Add tool call indicator to output
-                        var toolIndicator = $"\n\n🔧 `{parsedToolName}`\n\n";
+                        var toolIndicator = McpToolHelper.FormatToolCallDisplay(parsedToolName, toolArguments);
                         newContentBuilder.Append(toolIndicator);
                         fullContentBuilder.Append(toolIndicator);
                         yield return newContentBuilder.ToString();


### PR DESCRIPTION
## Summary
- Add `FormatToolCallDisplay` helper in `McpToolHelper` to format tool name with arguments
- Update all LLM services (OpenAI, Gemini, Anthropic, Ollama) to show tool parameters in the display message
- Long parameters truncated to 100 characters
- Replace newlines with spaces for clean display

## Before
```
🔧 `execute_command`
```

## After
```
🔧 `execute_command` [command: ls -la, cwd: /home/user]
```

This helps users understand what the LLM is actually doing when it calls tools.

## Files Changed
- `McpToolHelper.cs` - Added `FormatToolCallDisplay` helper
- `OpenAIService.cs` - Updated tool call display (3 locations)
- `GeminiService.cs` - Updated tool call display
- `AnthropicService.cs` - Updated tool call display (3 locations)
- `OllamaService.cs` - Updated tool call display
