### PR TITLE
fix: update Test project dependencies to resolve restore error

### DIFF
--- a/TelegramSearchBot.Test/TelegramSearchBot.Test.csproj
+++ b/TelegramSearchBot.Test/TelegramSearchBot.Test.csproj
@@ -8,8 +8,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">


### PR DESCRIPTION
## Summary

Fix GitHub Actions restore failure by updating Test project dependencies to match the main project.

## Problem

The previous PR #261 updated `Microsoft.Extensions.DependencyInjection` to version 10.0.6 in the main project, but the Test project still referenced version 10.0.3. This caused `dotnet restore` to fail with:

```
error NU1605: 检测到包降级: Microsoft.Extensions.DependencyInjection 从 10.0.6 降级到 10.0.3
```

## Solution

Update Test project's dependency references from 10.0.3 to 10.0.6:

```diff
- <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
- <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+ <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+ <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
```

## Verification

- `dotnet restore` passes with 0 errors
- `dotnet build --configuration Release` passes with 0 errors
