### PR TITLE
Fix Redis BRPOP timeout crashing background services

### DIFF
--- a/TelegramSearchBot/Service/AI/LLM/AgentRegistryService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/AgentRegistryService.cs
@@ -184,8 +184,21 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
             while (!stoppingToken.IsCancellationRequested) {
-                await RunMaintenanceOnceAsync(stoppingToken);
-                await Task.Delay(TimeSpan.FromSeconds(Math.Max(5, Env.AgentHeartbeatIntervalSeconds)), stoppingToken);
+                try {
+                    await RunMaintenanceOnceAsync(stoppingToken);
+                } catch (OperationCanceledException) {
+                    break;
+                } catch (RedisException ex) {
+                    _logger.LogWarning(ex, "Redis error in AgentRegistryService maintenance, retrying in 5 s");
+                } catch (Exception ex) {
+                    _logger.LogError(ex, "Unexpected error in AgentRegistryService maintenance");
+                }
+
+                try {
+                    await Task.Delay(TimeSpan.FromSeconds(Math.Max(5, Env.AgentHeartbeatIntervalSeconds)), stoppingToken);
+                } catch (OperationCanceledException) {
+                    break;
+                }
             }
         }
 

--- a/TelegramSearchBot/Service/AI/LLM/TelegramTaskConsumer.cs
+++ b/TelegramSearchBot/Service/AI/LLM/TelegramTaskConsumer.cs
@@ -30,57 +30,65 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken) {
             while (!stoppingToken.IsCancellationRequested) {
-                var result = await _redis.GetDatabase().ExecuteAsync("BRPOP", LlmAgentRedisKeys.TelegramTaskQueue, 5);
-                if (result.IsNull) {
-                    continue;
-                }
-
-                var parts = (RedisResult[])result!;
-                if (parts.Length != 2) {
-                    continue;
-                }
-
-                var payload = parts[1].ToString();
-                if (string.IsNullOrWhiteSpace(payload)) {
-                    continue;
-                }
-
-                var task = JsonConvert.DeserializeObject<TelegramAgentToolTask>(payload);
-                if (task == null) {
-                    continue;
-                }
-
-                var response = new TelegramAgentToolResult {
-                    RequestId = task.RequestId,
-                    Success = false
-                };
-
                 try {
-                    if (!task.ToolName.Equals("send_message", StringComparison.OrdinalIgnoreCase)) {
-                        throw new InvalidOperationException($"Unsupported telegram tool: {task.ToolName}");
+                    // Use a 2-second block time so BRPOP returns well within SE.Redis's 5 s async timeout.
+                    var result = await _redis.GetDatabase().ExecuteAsync("BRPOP", LlmAgentRedisKeys.TelegramTaskQueue, 2);
+                    if (result.IsNull) {
+                        continue;
                     }
 
-                    if (!task.Arguments.TryGetValue("text", out var text) || string.IsNullOrWhiteSpace(text)) {
-                        throw new InvalidOperationException("send_message 缺少 text 参数。");
+                    var parts = (RedisResult[])result!;
+                    if (parts.Length != 2) {
+                        continue;
                     }
 
-                    var chatId = task.Arguments.TryGetValue("chatId", out var chatIdString) && long.TryParse(chatIdString, out var parsedChatId)
-                        ? parsedChatId
-                        : task.ChatId;
+                    var payload = parts[1].ToString();
+                    if (string.IsNullOrWhiteSpace(payload)) {
+                        continue;
+                    }
 
-                    var sent = await _sendMessage.AddTaskWithResult(() => _botClient.SendMessage(chatId, text, cancellationToken: stoppingToken), chatId);
-                    response.Success = true;
-                    response.TelegramMessageId = sent.MessageId;
-                    response.Result = sent.MessageId.ToString();
-                } catch (Exception ex) {
-                    _logger.LogError(ex, "Failed to execute telegram task {RequestId}", task.RequestId);
-                    response.ErrorMessage = ex.Message;
+                    var task = JsonConvert.DeserializeObject<TelegramAgentToolTask>(payload);
+                    if (task == null) {
+                        continue;
+                    }
+
+                    var response = new TelegramAgentToolResult {
+                        RequestId = task.RequestId,
+                        Success = false
+                    };
+
+                    try {
+                        if (!task.ToolName.Equals("send_message", StringComparison.OrdinalIgnoreCase)) {
+                            throw new InvalidOperationException($"Unsupported telegram tool: {task.ToolName}");
+                        }
+
+                        if (!task.Arguments.TryGetValue("text", out var text) || string.IsNullOrWhiteSpace(text)) {
+                            throw new InvalidOperationException("send_message 缺少 text 参数。");
+                        }
+
+                        var chatId = task.Arguments.TryGetValue("chatId", out var chatIdString) && long.TryParse(chatIdString, out var parsedChatId)
+                            ? parsedChatId
+                            : task.ChatId;
+
+                        var sent = await _sendMessage.AddTaskWithResult(() => _botClient.SendMessage(chatId, text, cancellationToken: stoppingToken), chatId);
+                        response.Success = true;
+                        response.TelegramMessageId = sent.MessageId;
+                        response.Result = sent.MessageId.ToString();
+                    } catch (Exception ex) when (ex is not OperationCanceledException) {
+                        _logger.LogError(ex, "Failed to execute telegram task {RequestId}", task.RequestId);
+                        response.ErrorMessage = ex.Message;
+                    }
+
+                    await _redis.GetDatabase().StringSetAsync(
+                        LlmAgentRedisKeys.TelegramResult(task.RequestId),
+                        JsonConvert.SerializeObject(response),
+                        TimeSpan.FromMinutes(5));
+                } catch (OperationCanceledException) {
+                    break;
+                } catch (RedisException ex) {
+                    _logger.LogWarning(ex, "Redis error in TelegramTaskConsumer, retrying in 1 s");
+                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
                 }
-
-                await _redis.GetDatabase().StringSetAsync(
-                    LlmAgentRedisKeys.TelegramResult(task.RequestId),
-                    JsonConvert.SerializeObject(response),
-                    TimeSpan.FromMinutes(5));
             }
         }
     }


### PR DESCRIPTION
## Problem
After ~286s uptime, TelegramTaskConsumer and AgentRegistryService crashed with:
\\\
StackExchange.Redis.RedisTimeoutException: Timeout awaiting response ... command=BRPOP ... 5016ms elapsed, timeout is 5000ms
\\\
Both exceptions propagated out of \ExecuteAsync\, triggering \BackgroundServiceExceptionBehavior.StopHost\ and killing the process.

## Root Cause
- \TelegramTaskConsumer\ called \BRPOP key 5\ (5-second block time) while SE.Redis \syncTimeout\ is also 5000ms — a race where the client timeout and BRPOP timeout fire nearly simultaneously
- Neither \ExecuteAsync\ caught \RedisException\, so any transient Redis hiccup would crash the host

## Fix
- Reduce BRPOP block time to **2 seconds** (well within 5000ms client timeout)
- Wrap each service's loop body with \catch (RedisException)\ → log warning + retry
- Let \OperationCanceledException\ propagate normally for clean shutdown

## Testing
- All 6 agent/registry integration tests pass
- Build clean (0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system resilience with enhanced error handling and automatic retry logic for transient connection failures.
  * Enhanced responsiveness to shutdown and cancellation requests.
  * Optimized request timeouts for better operational performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->