### PR TITLE
fix: MCP tool refresh, final message delivery, and overflow retry

### DIFF
--- a/TelegramSearchBot.LLM.Test/Service/Tools/McpInstallerToolServiceTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/Tools/McpInstallerToolServiceTests.cs
@@ -16,6 +16,7 @@ using TelegramSearchBot.Model.Mcp;
 using TelegramSearchBot.Service.AI.LLM;
 using TelegramSearchBot.Service.Mcp;
 using TelegramSearchBot.Service.Tools;
+using StackExchange.Redis;
 using Xunit;
 
 namespace TelegramSearchBot.Test.Service.Tools {
@@ -50,7 +51,10 @@ namespace TelegramSearchBot.Test.Service.Tools {
             _mcpServerManager = new McpServerManager(managerLoggerMock.Object, scopeFactory);
 
             var serviceLoggerMock = new Mock<ILogger<McpInstallerToolService>>();
-            _service = new McpInstallerToolService(serviceLoggerMock.Object, _mcpServerManager);
+            var redisMock = new Mock<IConnectionMultiplexer>();
+            var dbMock = new Mock<IDatabase>();
+            redisMock.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+            _service = new McpInstallerToolService(serviceLoggerMock.Object, _mcpServerManager, redisMock.Object);
 
             _adminContext = new ToolContext { ChatId = 1, UserId = Env.AdminId };
             _nonAdminContext = new ToolContext { ChatId = 1, UserId = long.MaxValue - 1 };

--- a/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
@@ -1061,6 +1061,17 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         /// <summary>
+        /// Re-exports tool definitions to Redis so that newly spawned agent processes
+        /// discover the latest available tools (including any MCP servers added/removed at runtime).
+        /// </summary>
+        public static async Task RefreshAgentToolDefsInRedisAsync(StackExchange.Redis.IConnectionMultiplexer redis) {
+            var toolDefs = ExportToolDefinitions();
+            var json = JsonConvert.SerializeObject(toolDefs);
+            await redis.GetDatabase().StringSetAsync(
+                LlmAgentRedisKeys.AgentToolDefs, json, TimeSpan.FromHours(24));
+        }
+
+        /// <summary>
         /// Registers proxy tools that are executed remotely via IPC (e.g., agent calling main process tools).
         /// Unlike RegisterExternalTools, this preserves original tool names without any prefix.
         /// Tools already registered locally (in ToolRegistry) are skipped.

--- a/TelegramSearchBot.LLM/Service/Tools/McpInstallerToolService.cs
+++ b/TelegramSearchBot.LLM/Service/Tools/McpInstallerToolService.cs
@@ -24,14 +24,17 @@ namespace TelegramSearchBot.Service.Tools {
     public class McpInstallerToolService : IService, IMcpInstallerToolService {
         private readonly ILogger<McpInstallerToolService> _logger;
         private readonly IMcpServerManager _mcpServerManager;
+        private readonly StackExchange.Redis.IConnectionMultiplexer _redis;
 
         public string ServiceName => "McpInstallerToolService";
 
         public McpInstallerToolService(
             ILogger<McpInstallerToolService> logger,
-            IMcpServerManager mcpServerManager) {
+            IMcpServerManager mcpServerManager,
+            StackExchange.Redis.IConnectionMultiplexer redis) {
             _logger = logger;
             _mcpServerManager = mcpServerManager;
+            _redis = redis;
         }
 
         [BuiltInTool("List all configured MCP (Model Context Protocol) tool servers and their status. Shows server name, command, and available tools.")]
@@ -132,6 +135,7 @@ Only available to admin users.")]
 
                 // Re-register tools with McpToolHelper so new tools appear in LLM prompts
                 McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(_redis);
 
                 // Check if tools were discovered
                 var tools = _mcpServerManager.GetAllExternalTools()
@@ -182,6 +186,7 @@ Only available to admin users.")]
 
                 // Re-register tools with McpToolHelper to remove stale tool entries
                 McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(_redis);
 
                 return $"Successfully removed MCP server '{name}'.";
             } catch (Exception ex) {
@@ -277,6 +282,7 @@ Only available to admin users.")]
 
                 // Re-register tools with McpToolHelper to reflect any changes
                 McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(_redis);
 
                 if (!changes.Any()) {
                     return $"No changes were applied to MCP server '{name}'. Provide at least one parameter to update.";
@@ -301,6 +307,7 @@ Only available to admin users.")]
 
                 // Re-register tools with McpToolHelper so they appear in LLM prompts
                 McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(_redis);
 
                 var tools = _mcpServerManager.GetAllExternalTools();
                 return $"Successfully restarted MCP servers. {tools.Count} external tools available.";

--- a/TelegramSearchBot.Test/Service/AI/LLM/ChunkPollingServiceTests.cs
+++ b/TelegramSearchBot.Test/Service/AI/LLM/ChunkPollingServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Moq;
 using StackExchange.Redis;
@@ -54,12 +55,16 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
             var terminalChunk = new AgentStreamChunk {
                 TaskId = "task-2",
                 Type = AgentChunkType.Done,
-                Content = "final"
             };
             dbMock.Setup(d => d.StringGetAsync(
                     It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentTerminal("task-2")),
                     It.IsAny<CommandFlags>()))
                 .ReturnsAsync(Newtonsoft.Json.JsonConvert.SerializeObject(terminalChunk));
+            // No final snapshot
+            dbMock.Setup(d => d.StringGetAsync(
+                    It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentSnapshot("task-2")),
+                    It.IsAny<CommandFlags>()))
+                .ReturnsAsync(RedisValue.Null);
             dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
                 .ReturnsAsync(true);
 
@@ -69,6 +74,103 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
             await service.RunPollCycleAsync();
             var terminal = await handle.Completion;
 
+            Assert.Equal(AgentChunkType.Done, terminal.Type);
+        }
+
+        [Fact]
+        public async Task RunPollCycleAsync_DeliversFinalSnapshotBeforeClosingOnDone() {
+            // Scenario: agent published snapshots, then a Done terminal with empty content.
+            // The poller should read the final snapshot from Redis and deliver it before completing.
+            var redisMock = new Mock<IConnectionMultiplexer>();
+            var dbMock = new Mock<IDatabase>();
+            redisMock.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+
+            var terminalChunk = new AgentStreamChunk {
+                TaskId = "task-3",
+                Type = AgentChunkType.Done,
+            };
+            var finalSnapshot = new AgentStreamChunk {
+                TaskId = "task-3",
+                Type = AgentChunkType.Snapshot,
+                Content = "Final answer from the LLM agent",
+                Sequence = 5
+            };
+
+            dbMock.Setup(d => d.StringGetAsync(
+                    It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentTerminal("task-3")),
+                    It.IsAny<CommandFlags>()))
+                .ReturnsAsync(Newtonsoft.Json.JsonConvert.SerializeObject(terminalChunk));
+            dbMock.Setup(d => d.StringGetAsync(
+                    It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentSnapshot("task-3")),
+                    It.IsAny<CommandFlags>()))
+                .ReturnsAsync(Newtonsoft.Json.JsonConvert.SerializeObject(finalSnapshot));
+            dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+                .ReturnsAsync(true);
+
+            var service = new ChunkPollingService(redisMock.Object);
+            var handle = service.TrackTask("task-3");
+
+            await service.RunPollCycleAsync();
+
+            // Collect all yielded snapshots from the stream
+            var snapshots = new List<string>();
+            await foreach (var content in handle.ReadSnapshotsAsync()) {
+                snapshots.Add(content);
+            }
+
+            // The final snapshot content should have been delivered
+            Assert.Single(snapshots);
+            Assert.Equal("Final answer from the LLM agent", snapshots[0]);
+
+            // Terminal should be Done
+            var terminal = await handle.Completion;
+            Assert.Equal(AgentChunkType.Done, terminal.Type);
+        }
+
+        [Fact]
+        public async Task RunPollCycleAsync_TaskStateCompleted_DeliversLastContentFromState() {
+            // Scenario: No terminal key, no snapshot key, but task state says Completed with lastContent.
+            // The poller should deliver lastContent before completing the channel.
+            var redisMock = new Mock<IConnectionMultiplexer>();
+            var dbMock = new Mock<IDatabase>();
+            redisMock.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+
+            // No terminal
+            dbMock.Setup(d => d.StringGetAsync(
+                    It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentTerminal("task-4")),
+                    It.IsAny<CommandFlags>()))
+                .ReturnsAsync(RedisValue.Null);
+            // No snapshot key
+            dbMock.Setup(d => d.StringGetAsync(
+                    It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentSnapshot("task-4")),
+                    It.IsAny<CommandFlags>()))
+                .ReturnsAsync(RedisValue.Null);
+            // Task state shows completed with lastContent
+            dbMock.Setup(d => d.HashGetAllAsync(
+                    It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentTaskState("task-4")),
+                    It.IsAny<CommandFlags>()))
+                .ReturnsAsync([
+                    new HashEntry("status", AgentTaskStatus.Completed.ToString()),
+                    new HashEntry("lastContent", "Result stored in task state")
+                ]);
+            dbMock.Setup(d => d.KeyDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<CommandFlags>()))
+                .ReturnsAsync(true);
+
+            var service = new ChunkPollingService(redisMock.Object);
+            var handle = service.TrackTask("task-4");
+
+            await service.RunPollCycleAsync();
+
+            // Collect yielded snapshots
+            var snapshots = new List<string>();
+            await foreach (var content in handle.ReadSnapshotsAsync()) {
+                snapshots.Add(content);
+            }
+
+            Assert.Single(snapshots);
+            Assert.Equal("Result stored in task state", snapshots[0]);
+
+            var terminal = await handle.Completion;
             Assert.Equal(AgentChunkType.Done, terminal.Type);
         }
     }

--- a/TelegramSearchBot/AppBootstrap/GeneralBootstrap.cs
+++ b/TelegramSearchBot/AppBootstrap/GeneralBootstrap.cs
@@ -171,11 +171,8 @@ namespace TelegramSearchBot.AppBootstrap {
             // Export tool definitions to Redis so agent processes can discover available tools
             try {
                 var redis = service.GetRequiredService<IConnectionMultiplexer>();
-                var toolDefs = McpToolHelper.ExportToolDefinitions();
-                var json = JsonConvert.SerializeObject(toolDefs);
-                await redis.GetDatabase().StringSetAsync(
-                    LlmAgentRedisKeys.AgentToolDefs, json, TimeSpan.FromHours(24));
-                Log.Information("Exported {Count} tool definitions to Redis for agent discovery.", toolDefs.Count);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(redis);
+                Log.Information("Exported tool definitions to Redis for agent discovery.");
             } catch (Exception ex) {
                 Log.Warning(ex, "Failed to export tool definitions to Redis. Agent processes may have limited tools.");
             }

--- a/TelegramSearchBot/Service/AI/LLM/ChunkPollingService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/ChunkPollingService.cs
@@ -81,10 +81,18 @@ namespace TelegramSearchBot.Service.AI.LLM {
             if (terminalJson.HasValue) {
                 var terminal = JsonConvert.DeserializeObject<AgentStreamChunk>(terminalJson.ToString());
                 if (terminal != null) {
-                    // Deliver any final snapshot content before the terminal chunk
-                    if (!string.IsNullOrEmpty(terminal.Content) && terminal.Content != tracked.LastContent) {
+                    // Before completing, read the final snapshot from Redis and deliver it
+                    // so the consumer (SendDraftStream/SendFullMessageStream) sees the last content.
+                    await DeliverFinalSnapshotAsync(taskId, tracked, db, cancellationToken);
+
+                    // For IterationLimitReached, also deliver the terminal content if different
+                    if (terminal.Type == AgentChunkType.IterationLimitReached
+                        && !string.IsNullOrEmpty(terminal.Content)
+                        && terminal.Content != tracked.LastContent) {
                         await tracked.Channel.Writer.WriteAsync(terminal, cancellationToken);
+                        tracked.LastContent = terminal.Content;
                     }
+
                     tracked.Completion.TrySetResult(terminal);
                     tracked.Channel.Writer.TryComplete();
                     _trackedTasks.TryRemove(taskId, out _);
@@ -117,7 +125,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         private async Task TryCompleteFromTaskStateAsync(string taskId, TrackedTask tracked, CancellationToken cancellationToken) {
-            var entries = await _redis.GetDatabase().HashGetAllAsync(LlmAgentRedisKeys.AgentTaskState(taskId));
+            var db = _redis.GetDatabase();
+            var entries = await db.HashGetAllAsync(LlmAgentRedisKeys.AgentTaskState(taskId));
             if (entries.Length == 0) {
                 return;
             }
@@ -138,6 +147,23 @@ namespace TelegramSearchBot.Service.AI.LLM {
             }
 
             if (status == AgentTaskStatus.Completed) {
+                // Deliver the final snapshot before completing
+                await DeliverFinalSnapshotAsync(taskId, tracked, db, cancellationToken);
+
+                // Also check task state for lastContent as a fallback
+                var lastContentEntry = entries.FirstOrDefault(x => x.Name == "lastContent");
+                if (lastContentEntry.Value.HasValue) {
+                    var lastContent = lastContentEntry.Value.ToString();
+                    if (!string.IsNullOrEmpty(lastContent) && lastContent != tracked.LastContent) {
+                        await tracked.Channel.Writer.WriteAsync(new AgentStreamChunk {
+                            TaskId = taskId,
+                            Type = AgentChunkType.Snapshot,
+                            Content = lastContent
+                        }, cancellationToken);
+                        tracked.LastContent = lastContent;
+                    }
+                }
+
                 await CompleteTrackedTaskAsync(taskId, tracked, new AgentStreamChunk {
                     TaskId = taskId,
                     Type = AgentChunkType.Done
@@ -146,12 +172,30 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         private async Task CompleteTrackedTaskAsync(string taskId, TrackedTask tracked, AgentStreamChunk chunk, CancellationToken cancellationToken) {
-            await tracked.Channel.Writer.WriteAsync(chunk, cancellationToken);
             tracked.Completion.TrySetResult(chunk);
             tracked.Channel.Writer.TryComplete();
             _trackedTasks.TryRemove(taskId, out _);
             _ = _redis.GetDatabase().KeyDeleteAsync(LlmAgentRedisKeys.AgentSnapshot(taskId));
             _ = _redis.GetDatabase().KeyDeleteAsync(LlmAgentRedisKeys.AgentTerminal(taskId));
+        }
+
+        /// <summary>
+        /// Read the final snapshot from Redis and deliver it to the channel if it
+        /// differs from the last content already delivered.
+        /// </summary>
+        private async Task DeliverFinalSnapshotAsync(string taskId, TrackedTask tracked, IDatabase db, CancellationToken cancellationToken) {
+            try {
+                var snapshotJson = await db.StringGetAsync(LlmAgentRedisKeys.AgentSnapshot(taskId));
+                if (!snapshotJson.HasValue) return;
+
+                var snapshot = JsonConvert.DeserializeObject<AgentStreamChunk>(snapshotJson.ToString());
+                if (snapshot != null && !string.IsNullOrEmpty(snapshot.Content) && snapshot.Content != tracked.LastContent) {
+                    tracked.LastContent = snapshot.Content;
+                    await tracked.Channel.Writer.WriteAsync(snapshot, cancellationToken);
+                }
+            } catch (Exception) {
+                // Best-effort: don't let snapshot read failure prevent task completion
+            }
         }
 
         private sealed class TrackedTask {

--- a/TelegramSearchBot/Service/BotAPI/SendMessageService.Streaming.cs
+++ b/TelegramSearchBot/Service/BotAPI/SendMessageService.Streaming.cs
@@ -123,6 +123,7 @@ namespace TelegramSearchBot.Service.BotAPI {
 
             string latestMarkdownSnapshot = null;
             string markdownActuallySynced = null;
+            bool lastSyncComplete = true;
             List<string> chunksForDb = new List<string>();
             bool isFirstSync = true;
 
@@ -147,10 +148,9 @@ namespace TelegramSearchBot.Service.BotAPI {
 
                     lastApiSyncTime = DateTime.UtcNow;
                     isFirstSync = false;
-                    markdownActuallySynced = latestMarkdownSnapshot;
 
-                    chunksForDb = MessageFormatHelper.SplitMarkdownIntoChunks(markdownActuallySynced, 1900);
-                    if (!chunksForDb.Any() && !string.IsNullOrEmpty(markdownActuallySynced)) {
+                    chunksForDb = MessageFormatHelper.SplitMarkdownIntoChunks(latestMarkdownSnapshot, 1900);
+                    if (!chunksForDb.Any() && !string.IsNullOrEmpty(latestMarkdownSnapshot)) {
                         chunksForDb.Add(string.Empty);
                     }
 
@@ -159,10 +159,14 @@ namespace TelegramSearchBot.Service.BotAPI {
                     );
                     sentTelegramMessages = syncResult.UpdatedMessages;
                     lastSentHtmlPerMessageId = syncResult.UpdatedHtmlMap;
+                    lastSyncComplete = syncResult.SyncComplete;
+                    if (lastSyncComplete) {
+                        markdownActuallySynced = latestMarkdownSnapshot;
+                    }
                 }
             } catch (OperationCanceledException) { logger.LogInformation("SendFullMessageStream: Stream consumption cancelled."); } catch (Exception ex) { logger.LogError(ex, "SendFullMessageStream: Error during stream consumption."); }
 
-            if (latestMarkdownSnapshot != null && latestMarkdownSnapshot != markdownActuallySynced) {
+            if (latestMarkdownSnapshot != null && (latestMarkdownSnapshot != markdownActuallySynced || !lastSyncComplete)) {
                 logger.LogInformation("SendFullMessageStream: Performing final synchronization for the absolute latest content.");
                 chunksForDb = MessageFormatHelper.SplitMarkdownIntoChunks(latestMarkdownSnapshot, 1900);
                 if (!chunksForDb.Any() && !string.IsNullOrEmpty(latestMarkdownSnapshot)) chunksForDb.Add(string.Empty);
@@ -191,7 +195,7 @@ namespace TelegramSearchBot.Service.BotAPI {
         /// <param name="currentHtmlMap">当前HTML内容映射</param>
         /// <param name="cancellationToken">取消令牌</param>
         /// <returns>更新后的消息列表和HTML映射</returns>
-        private async Task<(List<Message> UpdatedMessages, Dictionary<int, string> UpdatedHtmlMap)> SynchronizeTelegramMessagesInternalAsync(
+        private async Task<(List<Message> UpdatedMessages, Dictionary<int, string> UpdatedHtmlMap, bool SyncComplete)> SynchronizeTelegramMessagesInternalAsync(
             long chatId,
             int originalReplyTo,
             List<string> newMarkdownChunks,
@@ -201,6 +205,7 @@ namespace TelegramSearchBot.Service.BotAPI {
             List<Message> nextTgMessagesState = new List<Message>();
             Dictionary<int, string> nextHtmlMap = new Dictionary<int, string>(currentHtmlMap);
             int effectiveReplyTo = originalReplyTo;
+            bool syncComplete = true;
 
             for (int i = 0; i < newMarkdownChunks.Count; i++) {
                 if (cancellationToken.IsCancellationRequested) throw new TaskCanceledException();
@@ -270,7 +275,10 @@ namespace TelegramSearchBot.Service.BotAPI {
                             } else {
                                 this.logger.LogWarning($"SynchronizeMessages: Sending new TG message for chunk {i} returned null or invalid Message object.");
                             }
-                        } catch (Exception ex) { this.logger.LogError(ex, $"SynchronizeMessages: Error sending new TG message for chunk {i}."); }
+                        } catch (Exception ex) {
+                            this.logger.LogError(ex, $"SynchronizeMessages: Error sending new TG message for chunk {i}.");
+                            syncComplete = false;
+                        }
                     }
                 }
             }
@@ -283,7 +291,7 @@ namespace TelegramSearchBot.Service.BotAPI {
                     nextHtmlMap.Remove(currentTgMessages[i].MessageId);
                 } catch (Exception ex) { this.logger.LogError(ex, $"SynchronizeMessages: Error deleting superfluous TG message {currentTgMessages[i].MessageId}."); }
             }
-            return (nextTgMessagesState, nextHtmlMap);
+            return (nextTgMessagesState, nextHtmlMap, syncComplete);
         }
 
         /// <summary>

--- a/TelegramSearchBot/Service/Manage/EditMcpConfService.cs
+++ b/TelegramSearchBot/Service/Manage/EditMcpConfService.cs
@@ -243,6 +243,7 @@ namespace TelegramSearchBot.Service.Manage {
             try {
                 await _mcpServerManager.AddServerAsync(config);
                 McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(connectionMultiplexer);
 
                 var tools = _mcpServerManager.GetAllExternalTools()
                     .Where(t => t.serverName == name).ToList();
@@ -389,6 +390,7 @@ namespace TelegramSearchBot.Service.Manage {
                 });
 
                 McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(connectionMultiplexer);
                 await redis.DeleteKeysAsync();
                 return (true, $"✅ MCP服务器 '{serverName}' {changeDescription}");
             } catch (Exception ex) {
@@ -430,6 +432,7 @@ namespace TelegramSearchBot.Service.Manage {
                 });
 
                 McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(connectionMultiplexer);
                 await redis.DeleteKeysAsync();
                 return (true, $"✅ MCP服务器 '{serverName}' 环境变量 '{envKey}' 已设置。");
             } catch (Exception ex) {
@@ -480,6 +483,7 @@ namespace TelegramSearchBot.Service.Manage {
                 try {
                     await _mcpServerManager.RemoveServerAsync(serverName);
                     McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                    await McpToolHelper.RefreshAgentToolDefsInRedisAsync(connectionMultiplexer);
                     await redis.DeleteKeysAsync();
                     return (true, $"✅ MCP服务器 '{serverName}' 已删除。");
                 } catch (Exception ex) {
@@ -544,6 +548,7 @@ namespace TelegramSearchBot.Service.Manage {
                 await _mcpServerManager.ShutdownAllAsync();
                 await _mcpServerManager.InitializeAllServersAsync();
                 McpToolHelper.RegisterExternalMcpTools(_mcpServerManager);
+                await McpToolHelper.RefreshAgentToolDefsInRedisAsync(connectionMultiplexer);
 
                 var tools = _mcpServerManager.GetAllExternalTools();
                 return (true, $"✅ MCP服务器已重启。共 {tools.Count} 个工具可用。");


### PR DESCRIPTION
## Summary

Fixes three bugs in the LLM agent process separation system:

### Bug 1: Final message content not delivered to Telegram
**Root cause**: When the agent completes (Done terminal), \ChunkPollingService\ checked \	erminal.Content\ which was empty for Done chunks, then immediately closed the channel without reading the final snapshot from Redis.

**Fix**: \PollTaskAsync\ now calls \DeliverFinalSnapshotAsync()\ to read the \AGENT_SNAPSHOT:{taskId}\ key and deliver it to the channel before closing. The \TryCompleteFromTaskStateAsync\ fallback path also reads both the snapshot key and \lastContent\ from task state hash.

### Bug 2: Overflow messages stuck when content spills to new TG message
**Root cause**: \markdownActuallySynced\ was set **before** calling \SynchronizeTelegramMessagesInternalAsync\, so if the sync partially failed (new message send error), the final retry check \latestMarkdownSnapshot != markdownActuallySynced\ was false — no retry happened.

**Fix**: \SynchronizeTelegramMessagesInternalAsync\ now returns a \SyncComplete\ flag. \markdownActuallySynced\ is only set after a fully successful sync, and the final retry condition also checks \!lastSyncComplete\.

### Bug 3: MCP tools not available after runtime changes
**Root cause**: Tool definitions were exported to Redis once at startup. When MCP servers were added/removed/restarted at runtime, \RegisterExternalMcpTools()\ updated the in-process registry, but the Redis key \AGENT_TOOL_DEFS\ was never refreshed.

**Fix**: Added \McpToolHelper.RefreshAgentToolDefsInRedisAsync()\ and call it after every \RegisterExternalMcpTools()\ in \EditMcpConfService\ (5 sites) and \McpInstallerToolService\ (4 sites). Startup also uses this centralized method.

## Tests
- Added 2 new tests for \ChunkPollingService\:
  - Terminal Done + snapshot in Redis → final snapshot delivered via stream
  - Task-state Completed + lastContent → content delivered as fallback
- All 417 tests pass (226 + 187 + 4)

## Files Changed
- \ChunkPollingService.cs\ - final snapshot delivery + helper method
- \SendMessageService.Streaming.cs\ - SyncComplete flag + conditional markdownActuallySynced
- \McpToolHelper.cs\ - \RefreshAgentToolDefsInRedisAsync()\ method
- \EditMcpConfService.cs\ - Redis refresh after MCP changes (5 sites)
- \McpInstallerToolService.cs\ - Redis refresh after MCP changes (4 sites) + DI for IConnectionMultiplexer
- \GeneralBootstrap.cs\ - use centralized refresh method
- Tests updated for new constructor + 2 new test cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Tool definitions are now cached in Redis for improved system performance.

* **Bug Fixes**
  * Improved handling of final snapshots in task polling.
  * Enhanced Telegram message synchronization with better completion state tracking for increased reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->