### PR TITLE
fix: run llm agent via self-fork bootstrap

### DIFF
--- a/TelegramSearchBot/AppBootstrap/AppBootstrap.cs
+++ b/TelegramSearchBot/AppBootstrap/AppBootstrap.cs
@@ -168,7 +168,7 @@ namespace TelegramSearchBot.AppBootstrap {
         }
 
         public static ChildProcessManager childProcessManager = new ChildProcessManager();
-        public static void Fork(string[] args, long? processMemoryLimitBytes = null) {
+        public static Process Fork(string[] args, long? processMemoryLimitBytes = null) {
             string exePath = Environment.ProcessPath;
 
             // 将参数数组转换为空格分隔的字符串，并正确处理包含空格的参数
@@ -188,7 +188,8 @@ namespace TelegramSearchBot.AppBootstrap {
                 throw new Exception("启动新进程失败");
             }
             childProcessManager.AddProcess(newProcess, processMemoryLimitBytes);
-            Log.Logger.Information($"主进程：{args[0]} {args[1]}已启动");
+            Log.Logger.Information($"主进程：{string.Join(" ", args)}已启动");
+            return newProcess;
         }
         private static Dictionary<string, DateTime> ForkLock = new Dictionary<string, DateTime>();
         private static readonly AsyncLock _asyncLock = new AsyncLock();

--- a/TelegramSearchBot/AppBootstrap/LLMAgentBootstrap.cs
+++ b/TelegramSearchBot/AppBootstrap/LLMAgentBootstrap.cs
@@ -1,28 +1,12 @@
 using System;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
 using Serilog;
+using TelegramSearchBot.LLMAgent;
 
 namespace TelegramSearchBot.AppBootstrap {
     public class LLMAgentBootstrap : AppBootstrap {
         public static void Startup(string[] args) {
             try {
-                var effectiveArgs = args.Length > 0 && args[0].Equals("LLMAgent", StringComparison.OrdinalIgnoreCase)
-                    ? args.Skip(1).ToArray()
-                    : args;
-                var dllPath = Path.Combine(AppContext.BaseDirectory, "TelegramSearchBot.LLMAgent.dll");
-                if (!File.Exists(dllPath)) {
-                    throw new FileNotFoundException("LLMAgent executable not found.", dllPath);
-                }
-
-                using var process = Process.Start(new ProcessStartInfo {
-                    FileName = "dotnet",
-                    Arguments = $"\"{dllPath}\" {string.Join(" ", effectiveArgs)}",
-                    UseShellExecute = false
-                });
-                process?.WaitForExit();
-                Environment.ExitCode = process?.ExitCode ?? 1;
+                LLMAgentProgram.RunAsync(args).GetAwaiter().GetResult();
             } catch (Exception ex) {
                 Log.Error(ex, "LLMAgent startup failed.");
                 Environment.ExitCode = 1;

--- a/TelegramSearchBot/Service/AI/LLM/LlmAgentProcessLauncher.cs
+++ b/TelegramSearchBot/Service/AI/LLM/LlmAgentProcessLauncher.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Diagnostics;
-using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using TelegramSearchBot.AppBootstrap;
@@ -11,14 +10,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
         public Task<int> StartAsync(long chatId, CancellationToken cancellationToken = default) {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var dllPath = Path.Combine(AppContext.BaseDirectory, "TelegramSearchBot.LLMAgent.dll");
-            if (!File.Exists(dllPath)) {
-                throw new FileNotFoundException("LLMAgent executable not found.", dllPath);
-            }
-
             var process = AppBootstrap.AppBootstrap.Fork(
-                "dotnet",
-                [dllPath, chatId.ToString(), Env.SchedulerPort.ToString()],
+                ["LLMAgent", chatId.ToString(), Env.SchedulerPort.ToString()],
                 GetMemoryLimitBytes());
             return Task.FromResult(process.Id);
         }


### PR DESCRIPTION
## Summary
- start LLMAgent by self-forking the main TelegramSearchBot process instead of spawning `dotnet TelegramSearchBot.LLMAgent.dll`
- execute `LLMAgentProgram` directly inside `LLMAgentBootstrap`
- make `AppBootstrap.Fork(string[] args, ...)` return the spawned process so the launcher can keep tracking the child pid

## Validation
- `dotnet build TelegramSearchBot.sln`

## Why
This aligns LLMAgent with the existing multi-process bootstrap model used by the main app, keeps child processes under the same job object management path, and removes the extra external DLL launch hop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced startup logging to display complete command arguments for better debugging transparency.

* **Refactor**
  * Simplified internal application bootstrap process for more efficient component initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->