### PR TITLE
fix: avoid scheduler SQLite lockups

### DIFF
--- a/TelegramSearchBot.Database/Model/SearchCacheDbContext.cs
+++ b/TelegramSearchBot.Database/Model/SearchCacheDbContext.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Serilog;
+using TelegramSearchBot.Model.Data;
+
+namespace TelegramSearchBot.Model {
+    public class SearchCacheDbContext : DbContext {
+        public SearchCacheDbContext(DbContextOptions<SearchCacheDbContext> options) : base(options) { }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) {
+            optionsBuilder.LogTo(Log.Logger.Information, LogLevel.Information);
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder) {
+            base.OnModelCreating(modelBuilder);
+
+            modelBuilder.Entity<SearchPageCache>()
+                .HasIndex(cache => cache.UUID)
+                .IsUnique();
+        }
+
+        public virtual DbSet<SearchPageCache> SearchPageCaches { get; set; } = null!;
+    }
+}

--- a/TelegramSearchBot.Test/Service/BotAPI/SendServiceTests.cs
+++ b/TelegramSearchBot.Test/Service/BotAPI/SendServiceTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Telegram.Bot;
@@ -14,6 +13,7 @@ using TelegramSearchBot.Manager;
 using TelegramSearchBot.Model;
 using TelegramSearchBot.Model.Data;
 using TelegramSearchBot.Service.BotAPI;
+using TelegramSearchBot.Service.Search;
 using Xunit;
 using Message = TelegramSearchBot.Model.Data.Message;
 using SearchOption = TelegramSearchBot.Model.SearchOption;
@@ -26,17 +26,12 @@ namespace TelegramSearchBot.Test.Service.BotAPI {
         }
     }
 
-    public class TestDataDbContext : DataDbContext {
-        public TestDataDbContext(DbContextOptions<DataDbContext> options) : base(options) { }
-        public virtual DbSet<SearchPageCache> SearchPageCaches { get; set; } = null!;
-    }
-
     public class SendServiceTests {
         private Mock<ITelegramBotClient> _mockBotClient = null!;
         private Mock<SendMessage> _mockSendMessage = null!;
         private Mock<ILogger<SendMessage>> _mockLogger = null!;
-        private Mock<TestDataDbContext> _mockDbContext = null!;
-        private Mock<IMediator> _mockMediator = null!;
+        private SearchCacheDbContext _searchCacheDbContext = null!;
+        private SearchOptionStorageService _searchOptionStorageService = null!;
         private SendService _sendService = null!;
 
         public SendServiceTests() {
@@ -44,38 +39,15 @@ namespace TelegramSearchBot.Test.Service.BotAPI {
             _mockLogger = new Mock<ILogger<SendMessage>>();
             _mockSendMessage = new Mock<SendMessage>(_mockBotClient.Object, _mockLogger.Object);
 
-            var mockSearchPageCaches = new Mock<DbSet<SearchPageCache>>();
-            var data = new List<SearchPageCache>();
-
-            mockSearchPageCaches.As<IQueryable<SearchPageCache>>()
-                .Setup(m => m.Provider)
-                .Returns(data.AsQueryable().Provider);
-            mockSearchPageCaches.As<IQueryable<SearchPageCache>>()
-                .Setup(m => m.Expression)
-                .Returns(data.AsQueryable().Expression);
-            mockSearchPageCaches.As<IQueryable<SearchPageCache>>()
-                .Setup(m => m.ElementType)
-                .Returns(data.AsQueryable().ElementType);
-            mockSearchPageCaches.As<IQueryable<SearchPageCache>>()
-                .Setup(m => m.GetEnumerator())
-                .Returns(data.AsQueryable().GetEnumerator());
-
-            mockSearchPageCaches.Setup(m => m.AddAsync(It.IsAny<SearchPageCache>(), It.IsAny<CancellationToken>()))
-                .Callback<SearchPageCache, CancellationToken>((cache, _) => {
-                    data.Add(cache);
-                })
-                .Returns(ValueTask.FromResult(default(EntityEntry<SearchPageCache>)));
-
-            var options = new DbContextOptionsBuilder<DataDbContext>()
-                .UseInMemoryDatabase(databaseName: "TestDatabase")
+            var options = new DbContextOptionsBuilder<SearchCacheDbContext>()
+                .UseInMemoryDatabase(databaseName: $"SendServiceTests_{Guid.NewGuid():N}")
                 .Options;
-            _mockDbContext = new Mock<TestDataDbContext>(options);
-            _mockDbContext.Setup(x => x.SearchPageCaches).Returns(mockSearchPageCaches.Object);
-            _mockDbContext.Setup(x => x.SaveChangesAsync(default)).ReturnsAsync(1);
+            _searchCacheDbContext = new SearchCacheDbContext(options);
+            _searchOptionStorageService = new SearchOptionStorageService(
+                _searchCacheDbContext,
+                Mock.Of<ILogger<SearchOptionStorageService>>());
 
-            _mockMediator = new Mock<IMediator>();
-
-            _sendService = new SendService(_mockBotClient.Object, _mockSendMessage.Object, _mockDbContext.Object);
+            _sendService = new SendService(_mockBotClient.Object, _mockSendMessage.Object, _searchOptionStorageService);
         }
 
         [Fact]
@@ -88,8 +60,8 @@ namespace TelegramSearchBot.Test.Service.BotAPI {
         [Fact]
         public void Constructor_WithNullParameters_ThrowsException() {
             // Arrange & Act & Assert
-            Assert.Throws<ArgumentNullException>(() => new SendService(null, _mockSendMessage.Object, _mockDbContext.Object));
-            Assert.Throws<ArgumentNullException>(() => new SendService(_mockBotClient.Object, null, _mockDbContext.Object));
+            Assert.Throws<ArgumentNullException>(() => new SendService(null, _mockSendMessage.Object, _searchOptionStorageService));
+            Assert.Throws<ArgumentNullException>(() => new SendService(_mockBotClient.Object, null, _searchOptionStorageService));
             Assert.Throws<ArgumentNullException>(() => new SendService(_mockBotClient.Object, _mockSendMessage.Object, null));
         }
 
@@ -175,6 +147,7 @@ namespace TelegramSearchBot.Test.Service.BotAPI {
             // Assert
             Assert.Equal(2, buttons.Count);
             Assert.Equal("下一页", buttons[0].Text);
+            Assert.Equal(2, await _searchCacheDbContext.SearchPageCaches.CountAsync());
         }
 
         [Fact]

--- a/TelegramSearchBot.Test/Service/Scheduler/SearchPageCacheCleanupTaskTests.cs
+++ b/TelegramSearchBot.Test/Service/Scheduler/SearchPageCacheCleanupTaskTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Model.Data;
+using TelegramSearchBot.Service.Scheduler;
+using Xunit;
+
+namespace TelegramSearchBot.Test.Service.Scheduler {
+    public sealed class SearchPageCacheCleanupTaskTests : IDisposable {
+        private readonly SqliteConnection _connection;
+        private readonly ServiceProvider _serviceProvider;
+
+        public SearchPageCacheCleanupTaskTests() {
+            _connection = new SqliteConnection("Data Source=:memory:");
+            _connection.Open();
+
+            var services = new ServiceCollection();
+            services.AddDbContext<DataDbContext>(
+                options => options.UseSqlite(_connection),
+                ServiceLifetime.Transient);
+
+            _serviceProvider = services.BuildServiceProvider();
+
+            using var scope = _serviceProvider.CreateScope();
+            using var dbContext = scope.ServiceProvider.GetRequiredService<DataDbContext>();
+            dbContext.Database.EnsureCreated();
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_DeletesExpiredCaches_AndKeepsRecentEntries() {
+            using (var scope = _serviceProvider.CreateScope()) {
+                using var dbContext = scope.ServiceProvider.GetRequiredService<DataDbContext>();
+                dbContext.SearchPageCaches.AddRange(
+                    new SearchPageCache {
+                        UUID = "expired-cache",
+                        SearchOptionJson = "{}",
+                        CreatedTime = DateTime.UtcNow.AddMonths(-2)
+                    },
+                    new SearchPageCache {
+                        UUID = "recent-cache",
+                        SearchOptionJson = "{}",
+                        CreatedTime = DateTime.UtcNow.AddDays(-7)
+                    });
+
+                await dbContext.SaveChangesAsync();
+            }
+
+            var heartbeatCount = 0;
+            var task = new SearchPageCacheCleanupTask(
+                _serviceProvider,
+                Mock.Of<ILogger<SearchPageCacheCleanupTask>>());
+            task.SetHeartbeatCallback(() => {
+                heartbeatCount++;
+                return Task.CompletedTask;
+            });
+
+            await task.ExecuteAsync();
+
+            using var verificationScope = _serviceProvider.CreateScope();
+            using var verificationContext = verificationScope.ServiceProvider.GetRequiredService<DataDbContext>();
+            var caches = await verificationContext.SearchPageCaches
+                .OrderBy(cache => cache.UUID)
+                .ToListAsync();
+
+            Assert.Single(caches);
+            Assert.Equal("recent-cache", caches[0].UUID);
+            Assert.True(heartbeatCount >= 2);
+        }
+
+        public void Dispose() {
+            _serviceProvider.Dispose();
+            _connection.Dispose();
+        }
+    }
+}

--- a/TelegramSearchBot.Test/Service/Scheduler/SearchPageCacheCleanupTaskTests.cs
+++ b/TelegramSearchBot.Test/Service/Scheduler/SearchPageCacheCleanupTaskTests.cs
@@ -21,21 +21,21 @@ namespace TelegramSearchBot.Test.Service.Scheduler {
             _connection.Open();
 
             var services = new ServiceCollection();
-            services.AddDbContext<DataDbContext>(
+            services.AddDbContext<SearchCacheDbContext>(
                 options => options.UseSqlite(_connection),
                 ServiceLifetime.Transient);
 
             _serviceProvider = services.BuildServiceProvider();
 
             using var scope = _serviceProvider.CreateScope();
-            using var dbContext = scope.ServiceProvider.GetRequiredService<DataDbContext>();
+            using var dbContext = scope.ServiceProvider.GetRequiredService<SearchCacheDbContext>();
             dbContext.Database.EnsureCreated();
         }
 
         [Fact]
         public async Task ExecuteAsync_DeletesExpiredCaches_AndKeepsRecentEntries() {
             using (var scope = _serviceProvider.CreateScope()) {
-                using var dbContext = scope.ServiceProvider.GetRequiredService<DataDbContext>();
+                using var dbContext = scope.ServiceProvider.GetRequiredService<SearchCacheDbContext>();
                 dbContext.SearchPageCaches.AddRange(
                     new SearchPageCache {
                         UUID = "expired-cache",
@@ -63,7 +63,7 @@ namespace TelegramSearchBot.Test.Service.Scheduler {
             await task.ExecuteAsync();
 
             using var verificationScope = _serviceProvider.CreateScope();
-            using var verificationContext = verificationScope.ServiceProvider.GetRequiredService<DataDbContext>();
+            using var verificationContext = verificationScope.ServiceProvider.GetRequiredService<SearchCacheDbContext>();
             var caches = await verificationContext.SearchPageCaches
                 .OrderBy(cache => cache.UUID)
                 .ToListAsync();

--- a/TelegramSearchBot/AppBootstrap/GeneralBootstrap.cs
+++ b/TelegramSearchBot/AppBootstrap/GeneralBootstrap.cs
@@ -180,8 +180,10 @@ namespace TelegramSearchBot.AppBootstrap {
             // SQLite 数据库初始化
             using (var serviceScope = service.GetService<IServiceScopeFactory>().CreateScope()) {
                 var context = serviceScope.ServiceProvider.GetRequiredService<DataDbContext>();
+                var searchCacheContext = serviceScope.ServiceProvider.GetRequiredService<SearchCacheDbContext>();
                 //context.Database.EnsureCreated();
                 context.Database.Migrate();
+                await searchCacheContext.Database.EnsureCreatedAsync();
             }
 
             // 启动Host，SchedulerService作为HostedService会自动启动

--- a/TelegramSearchBot/Executor/ControllerExecutor.cs
+++ b/TelegramSearchBot/Executor/ControllerExecutor.cs
@@ -27,7 +27,7 @@ namespace TelegramSearchBot.Executor {
                     try {
                         await controller.ExecuteAsync(PipelineContext);
                     } catch (Exception ex) {
-                        //Log.Error(ex, $"Message Pre Process Error: {e.Message.Chat.FirstName} {e.Message.Chat.LastName} {e.Message.Chat.Title} {e.Message.Chat.Id}/{e.Message.MessageId}");
+                        Log.Error(ex, "Controller {ControllerName} failed while handling update {UpdateId}", controller.GetType().Name, e.Id);
                     }
                     executed.Add(controller.GetType());
                     pending.Remove(controller);

--- a/TelegramSearchBot/Extension/ServiceCollectionExtension.cs
+++ b/TelegramSearchBot/Extension/ServiceCollectionExtension.cs
@@ -47,10 +47,18 @@ namespace TelegramSearchBot.Extension {
                 ConnectionMultiplexer.Connect(redisConnectionString));
         }
 
+        private static string BuildSqliteConnectionString(string databaseFileName) {
+            return $"Data Source={Path.Combine(Env.WorkDir, databaseFileName)};Cache=Shared;Mode=ReadWriteCreate;";
+        }
+
         public static IServiceCollection AddDatabase(this IServiceCollection services) {
-            return services.AddDbContext<DataDbContext>(options => {
-                options.UseSqlite($"Data Source={Path.Combine(Env.WorkDir, "Data.sqlite")};Cache=Shared;Mode=ReadWriteCreate;");
-            }, ServiceLifetime.Transient);
+            return services
+                .AddDbContext<DataDbContext>(options => {
+                    options.UseSqlite(BuildSqliteConnectionString("Data.sqlite"));
+                }, ServiceLifetime.Transient)
+                .AddDbContext<SearchCacheDbContext>(options => {
+                    options.UseSqlite(BuildSqliteConnectionString("SearchCache.sqlite"));
+                }, ServiceLifetime.Transient);
         }
 
         public static IServiceCollection AddHttpClients(this IServiceCollection services) {

--- a/TelegramSearchBot/Service/BotAPI/SendService.cs
+++ b/TelegramSearchBot/Service/BotAPI/SendService.cs
@@ -6,11 +6,11 @@ using Telegram.Bot;
 using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 using TelegramSearchBot.Attributes;
-using TelegramSearchBot.Extension;
 using TelegramSearchBot.Interface;
 using TelegramSearchBot.Manager;
 using TelegramSearchBot.Model;
 using TelegramSearchBot.Model.Data;
+using TelegramSearchBot.Service.Search;
 
 namespace TelegramSearchBot.Service.BotAPI {
 
@@ -18,14 +18,14 @@ namespace TelegramSearchBot.Service.BotAPI {
     public class SendService : IService {
         private readonly ITelegramBotClient botClient;
         private readonly SendMessage Send;
-        private readonly DataDbContext _dbContext;
+        private readonly SearchOptionStorageService _searchOptionStorageService;
 
         public string ServiceName => "SendService";
 
-        public SendService(ITelegramBotClient botClient, SendMessage Send, DataDbContext dbContext) {
+        public SendService(ITelegramBotClient botClient, SendMessage Send, SearchOptionStorageService searchOptionStorageService) {
             this.Send = Send ?? throw new ArgumentNullException(nameof(Send));
             this.botClient = botClient ?? throw new ArgumentNullException(nameof(botClient));
-            _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+            _searchOptionStorageService = searchOptionStorageService ?? throw new ArgumentNullException(nameof(searchOptionStorageService));
         }
         public static List<string> ConvertToList(IEnumerable<Message> messages) {
             var list = new List<string>();
@@ -65,16 +65,7 @@ namespace TelegramSearchBot.Service.BotAPI {
 
             searchOption.Skip += searchOption.Take;
             if (searchOption.Messages != null && searchOption.Messages.Count - searchOption.Take >= 0) {
-                var uuid_nxt = Guid.NewGuid().ToString();
-                var nextPageCache = new SearchPageCache() {
-                    UUID = uuid_nxt,
-                };
-                nextPageCache.SetSearchOption(searchOption);
-
-                if (_dbContext.SearchPageCaches != null) {
-                    _dbContext.SearchPageCaches.Add(nextPageCache);
-                    await _dbContext.SaveChangesAsync();
-                }
+                var uuid_nxt = await _searchOptionStorageService.SetSearchOptionAsync(searchOption);
 
                 keyboardList.Add(InlineKeyboardButton.WithCallbackData(
                     "下一页",
@@ -82,19 +73,8 @@ namespace TelegramSearchBot.Service.BotAPI {
                     ));
             }
 
-            var uuid = Guid.NewGuid().ToString();
-            searchOption.ToDeleteNow = true;
-            var deleteCache = new SearchPageCache() {
-                UUID = uuid,
-            };
-            deleteCache.SetSearchOption(searchOption);
-
-            if (_dbContext.SearchPageCaches != null) {
-                _dbContext.SearchPageCaches.Add(deleteCache);
-                await _dbContext.SaveChangesAsync();
-            }
-
-            searchOption.ToDeleteNow = false; //按理说不需要的
+            var deleteCache = _searchOptionStorageService.GetToDeleteNowSearchOption(searchOption);
+            var uuid = await _searchOptionStorageService.SetSearchOptionAsync(deleteCache);
             keyboardList.Add(InlineKeyboardButton.WithCallbackData(
                         "删除历史",
                         uuid

--- a/TelegramSearchBot/Service/Scheduler/SearchPageCacheCleanupTask.cs
+++ b/TelegramSearchBot/Service/Scheduler/SearchPageCacheCleanupTask.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using TelegramSearchBot.Attributes;
 using TelegramSearchBot.Model;
@@ -13,12 +14,12 @@ namespace TelegramSearchBot.Service.Scheduler {
 
         public string CronExpression => "0 4 1 * *"; // 每月1日凌晨4点执行，避开业务高峰
 
-        private readonly DataDbContext _dbContext;
+        private readonly IServiceProvider _serviceProvider;
         private readonly ILogger<SearchPageCacheCleanupTask> _logger;
         private Func<Task> _heartbeatCallback;
 
-        public SearchPageCacheCleanupTask(DataDbContext dbContext, ILogger<SearchPageCacheCleanupTask> logger) {
-            _dbContext = dbContext;
+        public SearchPageCacheCleanupTask(IServiceProvider serviceProvider, ILogger<SearchPageCacheCleanupTask> logger) {
+            _serviceProvider = serviceProvider;
             _logger = logger;
         }
 
@@ -30,10 +31,12 @@ namespace TelegramSearchBot.Service.Scheduler {
             _logger.LogInformation("搜索缓存清理任务开始执行");
 
             try {
+                using var scope = _serviceProvider.CreateScope();
+                var dbContext = scope.ServiceProvider.GetRequiredService<DataDbContext>();
                 var cutoffUtc = DateTime.UtcNow.AddMonths(-1);
                 _logger.LogInformation("开始清理 {CutoffUtc} 之前的 SearchPageCache 记录", cutoffUtc);
 
-                var outdatedQuery = _dbContext.SearchPageCaches
+                var outdatedQuery = dbContext.SearchPageCaches
                     .Where(cache => cache.CreatedTime < cutoffUtc);
 
                 // 预热心跳，防止长时间删除导致任务被误杀
@@ -54,8 +57,10 @@ namespace TelegramSearchBot.Service.Scheduler {
                     await _heartbeatCallback();
                 }
 
-                _logger.LogInformation("开始执行 SQLite VACUUM 以回收空间");
-                await _dbContext.Database.ExecuteSqlRawAsync("VACUUM;");
+                if (string.Equals(dbContext.Database.ProviderName, "Microsoft.EntityFrameworkCore.Sqlite", StringComparison.Ordinal)) {
+                    _logger.LogInformation("执行 SQLite PRAGMA optimize 进行轻量优化，跳过 VACUUM 以避免长时间数据库锁");
+                    await dbContext.Database.ExecuteSqlRawAsync("PRAGMA optimize;");
+                }
 
                 if (_heartbeatCallback != null) {
                     await _heartbeatCallback();

--- a/TelegramSearchBot/Service/Scheduler/SearchPageCacheCleanupTask.cs
+++ b/TelegramSearchBot/Service/Scheduler/SearchPageCacheCleanupTask.cs
@@ -32,7 +32,7 @@ namespace TelegramSearchBot.Service.Scheduler {
 
             try {
                 using var scope = _serviceProvider.CreateScope();
-                var dbContext = scope.ServiceProvider.GetRequiredService<DataDbContext>();
+                var dbContext = scope.ServiceProvider.GetRequiredService<SearchCacheDbContext>();
                 var cutoffUtc = DateTime.UtcNow.AddMonths(-1);
                 _logger.LogInformation("开始清理 {CutoffUtc} 之前的 SearchPageCache 记录", cutoffUtc);
 

--- a/TelegramSearchBot/Service/Scheduler/WordCloudTask.cs
+++ b/TelegramSearchBot/Service/Scheduler/WordCloudTask.cs
@@ -4,6 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using SixLabors.ImageSharp;
 using Telegram.Bot;
@@ -22,14 +23,14 @@ namespace TelegramSearchBot.Service.Scheduler {
 
         public string CronExpression => "0 5 * * *"; // 每天早上5点执行
 
-        private readonly DataDbContext _dbContext;
+        private readonly IServiceProvider _serviceProvider;
         private readonly ITelegramBotClient _botClient;
         private readonly SendMessage _sendMessage;
         private readonly ILogger<WordCloudTask> _logger;
         private Func<Task> _heartbeatCallback;
 
-        public WordCloudTask(DataDbContext dbContext, ITelegramBotClient botClient, SendMessage sendMessage, ILogger<WordCloudTask> logger) {
-            _dbContext = dbContext;
+        public WordCloudTask(IServiceProvider serviceProvider, ITelegramBotClient botClient, SendMessage sendMessage, ILogger<WordCloudTask> logger) {
+            _serviceProvider = serviceProvider;
             _botClient = botClient;
             _sendMessage = sendMessage;
             _logger = logger;
@@ -42,9 +43,12 @@ namespace TelegramSearchBot.Service.Scheduler {
         public async Task ExecuteAsync() {
             _logger.LogInformation("词云报告任务开始执行");
 
+            using var scope = _serviceProvider.CreateScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<DataDbContext>();
+
             // 检查今天是否已经成功执行过
             var todayUtc = DateTime.UtcNow.Date;
-            var lastSuccessfulExecution = await _dbContext.ScheduledTaskExecutions
+            var lastSuccessfulExecution = await dbContext.ScheduledTaskExecutions
                 .Where(e => e.TaskName == TaskName && e.Status == TaskExecutionStatus.Completed)
                 .OrderByDescending(e => e.CompletedTime)
                 .FirstOrDefaultAsync();
@@ -73,7 +77,7 @@ namespace TelegramSearchBot.Service.Scheduler {
 
             if (period.HasValue) {
                 _logger.LogInformation("符合条件, 开始生成 {Period} 词云报告", period.Value);
-                await SendWordCloudReportAsync(period.Value);
+                await SendWordCloudReportAsync(period.Value, dbContext);
             } else {
                 _logger.LogInformation("今天不符合任何报告生成条件, 跳过执行");
             }
@@ -108,10 +112,10 @@ namespace TelegramSearchBot.Service.Scheduler {
             }
         }
 
-        private async Task SendWordCloudReportAsync(TimePeriod period) {
+        private async Task SendWordCloudReportAsync(TimePeriod period, DataDbContext dbContext) {
             try {
-                var groupStats = await CountUserMessagesAsync(period);
-                var messagesByGroup = await GetGroupMessagesWithExtensionsAsync(period);
+                var groupStats = await CountUserMessagesAsync(dbContext, period);
+                var messagesByGroup = await GetGroupMessagesWithExtensionsAsync(dbContext, period);
 
                 foreach (var group in messagesByGroup) {
                     // 更新心跳
@@ -124,16 +128,28 @@ namespace TelegramSearchBot.Service.Scheduler {
                         continue;
                     }
 
-                    var topUsers = stats.UserCounts
+                    var topUserContributors = stats.UserCounts
                         .Where(kv => kv.Key != 0) // 排除系统用户
                         .OrderByDescending(kv => kv.Value)
                         .Take(3)
+                        .ToList();
+
+                    var topUserIds = topUserContributors
+                        .Select(kv => kv.Key)
+                        .ToList();
+
+                    var userNames = await dbContext.UserData
+                        .Where(u => topUserIds.Contains(u.Id))
+                        .ToDictionaryAsync(
+                            u => u.Id,
+                            u => string.IsNullOrWhiteSpace($"{u.FirstName} {u.LastName}".Trim())
+                                ? $"用户{u.Id}"
+                                : $"{u.FirstName} {u.LastName}".Trim());
+
+                    var topUsers = topUserContributors
                         .Select(kv => {
-                            var user = _dbContext.UserData.FirstOrDefault(u => u.Id == kv.Key);
-                            var name = user != null ?
-                                $"{user.FirstName} {user.LastName}".Trim() :
-                                $"用户{kv.Key}";
-                            return (Name: name, Count: kv.Value);
+                            var name = userNames.GetValueOrDefault(kv.Key, $"用户{kv.Key}");
+                            return ( Name: name, Count: kv.Value );
                         })
                         .ToList();
 
@@ -226,7 +242,7 @@ namespace TelegramSearchBot.Service.Scheduler {
         /// - UserCounts: 用户ID到发言数量的字典
         /// - TotalCount: 总发言数量
         /// </returns>
-        public async Task<Dictionary<long, (Dictionary<long, int> UserCounts, int TotalCount)>> CountUserMessagesAsync(TimePeriod period) {
+        public async Task<Dictionary<long, (Dictionary<long, int> UserCounts, int TotalCount)>> CountUserMessagesAsync(DataDbContext dbContext, TimePeriod period) {
             var startDate = period switch {
                 TimePeriod.Daily => DateTime.UtcNow.AddDays(-1),
                 TimePeriod.Weekly => DateTime.UtcNow.AddDays(-7),
@@ -236,7 +252,7 @@ namespace TelegramSearchBot.Service.Scheduler {
                 _ => DateTime.UtcNow.AddDays(-1)
             };
 
-            var messages = await _dbContext.Messages
+            var messages = await dbContext.Messages
                 .Where(m => m.DateTime >= startDate && m.GroupId < 0) // 只统计群聊
                 .ToListAsync();
 
@@ -262,7 +278,7 @@ namespace TelegramSearchBot.Service.Scheduler {
         /// 列表包含消息内容和所有扩展值（不包含扩展名）
         /// 没有消息的群组会被自动过滤掉
         /// </returns>
-        public async Task<Dictionary<long, List<string>>> GetGroupMessagesWithExtensionsAsync(TimePeriod period) {
+        public async Task<Dictionary<long, List<string>>> GetGroupMessagesWithExtensionsAsync(DataDbContext dbContext, TimePeriod period) {
             var result = new Dictionary<long, List<string>>();
             var startDate = period switch {
                 TimePeriod.Daily => DateTime.UtcNow.AddDays(-1),
@@ -273,12 +289,12 @@ namespace TelegramSearchBot.Service.Scheduler {
                 _ => DateTime.UtcNow.AddDays(-1)
             };
 
-            var groups = await _dbContext.GroupData
+            var groups = await dbContext.GroupData
                 .Where(g => g.Id < 0) // 只处理群组(GroupId < 0)，过滤私聊
                 .ToListAsync();
 
             foreach (var group in groups) {
-                var groupMessages = await _dbContext.Messages
+                var groupMessages = await dbContext.Messages
                     .Where(m => m.GroupId == group.Id && m.DateTime >= startDate)
                     .Include(m => m.MessageExtensions)
                     .ToListAsync();

--- a/TelegramSearchBot/Service/Search/SearchOptionStorageService.cs
+++ b/TelegramSearchBot/Service/Search/SearchOptionStorageService.cs
@@ -18,14 +18,14 @@ namespace TelegramSearchBot.Service.Search {
     [Injectable(Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient)]
     public class SearchOptionStorageService : IService {
         public string ServiceName => "SearchOptionStorageService";
-        private readonly DataDbContext _dataDbContext;
+        private readonly SearchCacheDbContext _searchCacheDbContext;
         private readonly ILogger<SearchOptionStorageService> _logger;
 
         public SearchOptionStorageService(
-            DataDbContext dataDbContext,
+            SearchCacheDbContext searchCacheDbContext,
             ILogger<SearchOptionStorageService> logger) {
             // 初始化搜索选项存储服务
-            _dataDbContext = dataDbContext ?? throw new ArgumentNullException(nameof(dataDbContext));
+            _searchCacheDbContext = searchCacheDbContext ?? throw new ArgumentNullException(nameof(searchCacheDbContext));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         }
         /// <summary>
@@ -43,7 +43,7 @@ namespace TelegramSearchBot.Service.Search {
 
             try {
                 // 从SearchPageCaches表中查找缓存
-                var cache = await _dataDbContext.SearchPageCaches
+                var cache = await _searchCacheDbContext.SearchPageCaches
                     .AsNoTracking()
                     .FirstOrDefaultAsync(c => c.UUID == UUID)
                     .ConfigureAwait(false);
@@ -59,8 +59,8 @@ namespace TelegramSearchBot.Service.Search {
                 var result = cache.GetSearchOption();
 
                 // 查询成功后删除记录
-                _dataDbContext.SearchPageCaches.Remove(cache);
-                await _dataDbContext.SaveChangesAsync().ConfigureAwait(false);
+                _searchCacheDbContext.SearchPageCaches.Remove(cache);
+                await _searchCacheDbContext.SaveChangesAsync().ConfigureAwait(false);
 
                 return result;
             } catch (Exception ex) {
@@ -87,8 +87,8 @@ namespace TelegramSearchBot.Service.Search {
                 };
                 cache.SetSearchOption(searchOption);
 
-                _dataDbContext.SearchPageCaches.Add(cache);
-                await _dataDbContext.SaveChangesAsync().ConfigureAwait(false);
+                _searchCacheDbContext.SearchPageCaches.Add(cache);
+                await _searchCacheDbContext.SaveChangesAsync().ConfigureAwait(false);
 
                 return uuid;
             } catch (Exception ex) {
@@ -146,14 +146,12 @@ namespace TelegramSearchBot.Service.Search {
         public async Task<int> CleanupOldSearchPageCachesAsync(TimeSpan timeSpan) {
             try {
                 var cutoffTime = DateTime.UtcNow.Subtract(timeSpan);
-                var oldCaches = _dataDbContext.SearchPageCaches
-                    .Where(c => c.CreatedTime < cutoffTime);
-
-                int deletedCount = await oldCaches.CountAsync().ConfigureAwait(false);
+                int deletedCount = await _searchCacheDbContext.SearchPageCaches
+                    .Where(c => c.CreatedTime < cutoffTime)
+                    .ExecuteDeleteAsync()
+                    .ConfigureAwait(false);
 
                 if (deletedCount > 0) {
-                    _dataDbContext.SearchPageCaches.RemoveRange(oldCaches);
-                    await _dataDbContext.SaveChangesAsync().ConfigureAwait(false);
                     _logger.LogInformation("Deleted {Count} old search page caches older than {Date}",
                         deletedCount, cutoffTime);
                 }


### PR DESCRIPTION
## Summary
- keep the earlier scheduler lockup fix in place
- move search pagination cache traffic into a dedicated SearchCache.sqlite database under Env.WorkDir`n- initialize the isolated cache database on startup and route cache writes/cleanup through SearchCacheDbContext`n- keep the primary Data.sqlite focused on durable bot data so cache churn no longer competes with message ingestion
- cover the isolated cache path in tests

## Why
SQLite serializes writers per database file. The original problem was not just multiple DbContext instances, but that cache cleanup and normal message persistence were contending on the same Data.sqlite file. By splitting disposable search-page cache data into its own SQLite file, cache writes and cleanup no longer block the main message-processing database.

## Validation
- dotnet build TelegramSearchBot.sln -c Release
- dotnet test TelegramSearchBot.sln -c Release --no-build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled error logging for failed controller executions to improve troubleshooting and monitoring.

* **Chores**
  * Optimized SQLite database maintenance during search cache cleanup operations.
  * Improved application initialization to properly set up all database components at startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->