### PR TITLE
fix: retry transient AI agent overload errors

### DIFF
--- a/TelegramSearchBot.LLMAgent/Service/AgentLoopService.cs
+++ b/TelegramSearchBot.LLMAgent/Service/AgentLoopService.cs
@@ -1,3 +1,6 @@
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -7,20 +10,24 @@ using TelegramSearchBot.Model.AI;
 
 namespace TelegramSearchBot.LLMAgent.Service {
     public sealed class AgentLoopService {
+        private const int MaxTransientOverloadRetries = 3;
         private readonly IServiceProvider _serviceProvider;
         private readonly GarnetClient _garnetClient;
         private readonly GarnetRpcClient _rpcClient;
         private readonly ILogger<AgentLoopService> _logger;
+        private readonly Func<int, TimeSpan> _transientRetryDelayFactory;
 
         public AgentLoopService(
             IServiceProvider serviceProvider,
             GarnetClient garnetClient,
             GarnetRpcClient rpcClient,
-            ILogger<AgentLoopService> logger) {
+            ILogger<AgentLoopService> logger,
+            Func<int, TimeSpan>? transientRetryDelayFactory = null) {
             _serviceProvider = serviceProvider;
             _garnetClient = garnetClient;
             _rpcClient = rpcClient;
             _logger = logger;
+            _transientRetryDelayFactory = transientRetryDelayFactory ?? GetDefaultTransientRetryDelay;
         }
 
         public async Task RunAsync(long chatId, int port, CancellationToken cancellationToken) {
@@ -126,70 +133,111 @@ namespace TelegramSearchBot.LLMAgent.Service {
             long workerChatId,
             string recoveredContent,
             CancellationToken cancellationToken) {
-            using var scope = _serviceProvider.CreateScope();
-            var executor = scope.ServiceProvider.GetRequiredService<IAgentTaskExecutor>();
-            var executionContext = new LlmExecutionContext();
             var sequence = 0;
-            var suppressUntilRecoveryCatchup = !string.IsNullOrWhiteSpace(recoveredContent);
+            var currentRecoveredContent = recoveredContent;
+            var latestSnapshot = recoveredContent;
+            var retryAttempt = 0;
 
-            try {
-                await foreach (var snapshot in executor.CallAsync(task, executionContext, cancellationToken).WithCancellation(cancellationToken)) {
-                    await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Running, null, new Dictionary<string, string> {
-                        ["lastContent"] = snapshot,
-                        ["lastSequence"] = sequence.ToString()
-                    });
+            while (true) {
+                using var scope = _serviceProvider.CreateScope();
+                var executor = scope.ServiceProvider.GetRequiredService<IAgentTaskExecutor>();
+                var executionContext = new LlmExecutionContext();
+                var suppressUntilRecoveryCatchup = !string.IsNullOrWhiteSpace(currentRecoveredContent);
 
-                    if (!ShouldPublishSnapshot(snapshot, recoveredContent, ref suppressUntilRecoveryCatchup)) {
-                        continue;
+                try {
+                    await foreach (var snapshot in executor.CallAsync(task, executionContext, cancellationToken).WithCancellation(cancellationToken)) {
+                        latestSnapshot = snapshot;
+                        await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Running, null, new Dictionary<string, string> {
+                            ["lastContent"] = snapshot,
+                            ["lastSequence"] = sequence.ToString()
+                        });
+
+                        if (!ShouldPublishSnapshot(snapshot, currentRecoveredContent, ref suppressUntilRecoveryCatchup)) {
+                            continue;
+                        }
+
+                        await _garnetClient.PublishSnapshotAsync(new AgentStreamChunk {
+                            TaskId = task.TaskId,
+                            Type = AgentChunkType.Snapshot,
+                            Sequence = sequence++,
+                            Content = snapshot
+                        });
                     }
 
-                    await _garnetClient.PublishSnapshotAsync(new AgentStreamChunk {
-                        TaskId = task.TaskId,
-                        Type = AgentChunkType.Snapshot,
-                        Sequence = sequence++,
-                        Content = snapshot
-                    });
-                }
+                    if (executionContext.IterationLimitReached && executionContext.SnapshotData != null) {
+                        await _garnetClient.PublishTerminalAsync(new AgentStreamChunk {
+                            TaskId = task.TaskId,
+                            Type = AgentChunkType.IterationLimitReached,
+                            Sequence = sequence++,
+                            Content = executionContext.SnapshotData.LastAccumulatedContent ?? string.Empty,
+                            ContinuationSnapshot = executionContext.SnapshotData
+                        });
+                        await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Completed, null, new Dictionary<string, string> {
+                            ["payload"] = payload,
+                            ["workerChatId"] = workerChatId.ToString(),
+                            ["lastContent"] = executionContext.SnapshotData.LastAccumulatedContent ?? string.Empty,
+                            ["completedAtUtc"] = DateTime.UtcNow.ToString("O"),
+                            ["transientRetryCount"] = retryAttempt.ToString()
+                        });
+                    } else {
+                        await _garnetClient.PublishTerminalAsync(new AgentStreamChunk {
+                            TaskId = task.TaskId,
+                            Type = AgentChunkType.Done,
+                            Sequence = sequence,
+                        });
+                        await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Completed, null, new Dictionary<string, string> {
+                            ["payload"] = payload,
+                            ["workerChatId"] = workerChatId.ToString(),
+                            ["completedAtUtc"] = DateTime.UtcNow.ToString("O"),
+                            ["transientRetryCount"] = retryAttempt.ToString()
+                        });
+                    }
 
-                if (executionContext.IterationLimitReached && executionContext.SnapshotData != null) {
-                    await _garnetClient.PublishTerminalAsync(new AgentStreamChunk {
-                        TaskId = task.TaskId,
-                        Type = AgentChunkType.IterationLimitReached,
-                        Sequence = sequence++,
-                        Content = executionContext.SnapshotData.LastAccumulatedContent ?? string.Empty,
-                        ContinuationSnapshot = executionContext.SnapshotData
-                    });
-                    await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Completed, null, new Dictionary<string, string> {
+                    return;
+                } catch (Exception ex) when (ShouldRetryTransientOverload(ex, retryAttempt, cancellationToken)) {
+                    retryAttempt++;
+                    var delay = _transientRetryDelayFactory(retryAttempt);
+                    currentRecoveredContent = latestSnapshot;
+
+                    _logger.LogWarning(
+                        ex,
+                        "Agent task {TaskId} hit transient LLM overload. Retrying in {DelaySeconds}s (attempt {RetryAttempt}/{MaxRetries})",
+                        task.TaskId,
+                        delay.TotalSeconds,
+                        retryAttempt,
+                        MaxTransientOverloadRetries);
+
+                    await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Running, null, new Dictionary<string, string> {
                         ["payload"] = payload,
                         ["workerChatId"] = workerChatId.ToString(),
-                        ["lastContent"] = executionContext.SnapshotData.LastAccumulatedContent ?? string.Empty,
-                        ["completedAtUtc"] = DateTime.UtcNow.ToString("O")
+                        ["lastContent"] = latestSnapshot,
+                        ["lastSequence"] = sequence.ToString(),
+                        ["transientRetryCount"] = retryAttempt.ToString(),
+                        ["lastRetryAtUtc"] = DateTime.UtcNow.ToString("O"),
+                        ["lastRetryReason"] = ex.Message
                     });
-                } else {
+
+                    if (delay > TimeSpan.Zero) {
+                        await Task.Delay(delay, cancellationToken);
+                    }
+                } catch (Exception ex) {
+                    _logger.LogError(ex, "Agent task {TaskId} failed", task.TaskId);
                     await _garnetClient.PublishTerminalAsync(new AgentStreamChunk {
                         TaskId = task.TaskId,
-                        Type = AgentChunkType.Done,
+                        Type = AgentChunkType.Error,
                         Sequence = sequence,
+                        ErrorMessage = ex.Message
                     });
-                    await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Completed, null, new Dictionary<string, string> {
+                    await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Failed, ex.Message, new Dictionary<string, string> {
                         ["payload"] = payload,
                         ["workerChatId"] = workerChatId.ToString(),
-                        ["completedAtUtc"] = DateTime.UtcNow.ToString("O")
+                        ["failedAtUtc"] = DateTime.UtcNow.ToString("O"),
+                        ["lastContent"] = latestSnapshot,
+                        ["lastSequence"] = sequence.ToString(),
+                        ["transientRetryCount"] = retryAttempt.ToString()
                     });
+                    return;
                 }
-            } catch (Exception ex) {
-                _logger.LogError(ex, "Agent task {TaskId} failed", task.TaskId);
-                await _garnetClient.PublishTerminalAsync(new AgentStreamChunk {
-                    TaskId = task.TaskId,
-                    Type = AgentChunkType.Error,
-                    Sequence = sequence,
-                    ErrorMessage = ex.Message
-                });
-                await _rpcClient.SaveTaskStateAsync(task.TaskId, AgentTaskStatus.Failed, ex.Message, new Dictionary<string, string> {
-                    ["payload"] = payload,
-                    ["workerChatId"] = workerChatId.ToString(),
-                    ["failedAtUtc"] = DateTime.UtcNow.ToString("O")
-                });
             }
         }
 
@@ -239,6 +287,74 @@ namespace TelegramSearchBot.LLMAgent.Service {
 
             suppressUntilRecoveryCatchup = false;
             return true;
+        }
+
+        private static TimeSpan GetDefaultTransientRetryDelay(int retryAttempt) {
+            var seconds = Math.Min(16, ( int ) Math.Pow(2, retryAttempt));
+            return TimeSpan.FromSeconds(seconds);
+        }
+
+        private static bool ShouldRetryTransientOverload(Exception ex, int retryAttempt, CancellationToken cancellationToken) {
+            if (cancellationToken.IsCancellationRequested || ex is OperationCanceledException) {
+                return false;
+            }
+
+            return retryAttempt < MaxTransientOverloadRetries && IsTransientOverloadException(ex);
+        }
+
+        private static bool IsTransientOverloadException(Exception ex) {
+            foreach (var current in EnumerateExceptions(ex)) {
+                var statusCode = TryGetStatusCode(current);
+                if (statusCode is 429 or 529) {
+                    return true;
+                }
+
+                var message = current.Message ?? string.Empty;
+                if (message.Contains("HTTP 529", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("overloaded_error", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("当前服务集群负载较高", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("当前时段请求拥挤", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("请稍后重试", StringComparison.OrdinalIgnoreCase) ||
+                    message.Contains("(2064)", StringComparison.OrdinalIgnoreCase)) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static IEnumerable<Exception> EnumerateExceptions(Exception ex) {
+            for (var current = ex; current != null; current = current.InnerException) {
+                yield return current;
+            }
+        }
+
+        private static int? TryGetStatusCode(Exception ex) {
+            if (ex is HttpRequestException httpRequestException && httpRequestException.StatusCode.HasValue) {
+                return ( int ) httpRequestException.StatusCode.Value;
+            }
+
+            foreach (var propertyName in new[] { "StatusCode", "Status" }) {
+                var property = ex.GetType().GetProperty(propertyName, BindingFlags.Public | BindingFlags.Instance);
+                if (property == null || property.GetIndexParameters().Length > 0) {
+                    continue;
+                }
+
+                var value = property.GetValue(ex);
+                if (value is int intValue) {
+                    return intValue;
+                }
+
+                if (value is long longValue && longValue is >= int.MinValue and <= int.MaxValue) {
+                    return ( int ) longValue;
+                }
+
+                if (value is HttpStatusCode httpStatusCode) {
+                    return ( int ) httpStatusCode;
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/TelegramSearchBot.Test/Service/AI/LLM/AgentIntegrationTests.cs
+++ b/TelegramSearchBot.Test/Service/AI/LLM/AgentIntegrationTests.cs
@@ -180,6 +180,84 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
             }
         }
 
+        [Fact]
+        public async Task ProcessTaskAsync_TransientOverload_RetriesAndCompletes() {
+            var harness = new InMemoryRedisTestHarness();
+            var attempts = 0;
+            var executor = CreateExecutor((_, _, _) => ExecuteWithTransientOverloadAsync(
+                () => ++attempts < 3,
+                "HTTP 529 (overloaded_error: )\n\n当前服务集群负载较高，请稍后重试，感谢您的耐心等待。 (2064)",
+                "final-answer"));
+            var loop = CreateAgentLoop(harness, executor, _ => TimeSpan.Zero);
+            var task = CreateExecutionTask();
+
+            await loop.ProcessTaskAsync(task, "payload", task.ChatId, string.Empty, CancellationToken.None);
+
+            var terminalJson = harness.GetString(LlmAgentRedisKeys.AgentTerminal(task.TaskId));
+            Assert.NotNull(terminalJson);
+            var terminal = Newtonsoft.Json.JsonConvert.DeserializeObject<AgentStreamChunk>(terminalJson!);
+            Assert.NotNull(terminal);
+            Assert.Equal(AgentChunkType.Done, terminal!.Type);
+            Assert.Equal(3, attempts);
+
+            var state = harness.GetHash(LlmAgentRedisKeys.AgentTaskState(task.TaskId));
+            Assert.Equal(AgentTaskStatus.Completed.ToString(), state["status"]);
+            Assert.Equal("2", state["transientRetryCount"]);
+        }
+
+        [Fact]
+        public async Task ProcessTaskAsync_TransientOverloadBeyondLimit_FailsAfterRetries() {
+            var harness = new InMemoryRedisTestHarness();
+            var attempts = 0;
+            var executor = CreateExecutor((_, _, _) => ExecuteWithTransientOverloadAsync(
+                () => {
+                    attempts++;
+                    return true;
+                },
+                "HTTP 529 (overloaded_error: )\n\n当前时段请求拥挤，极速版套餐可使用highspeed模型，享受更稳定的响应体验。 (2064)",
+                "unreachable"));
+            var loop = CreateAgentLoop(harness, executor, _ => TimeSpan.Zero);
+            var task = CreateExecutionTask();
+
+            await loop.ProcessTaskAsync(task, "payload", task.ChatId, string.Empty, CancellationToken.None);
+
+            var terminalJson = harness.GetString(LlmAgentRedisKeys.AgentTerminal(task.TaskId));
+            Assert.NotNull(terminalJson);
+            var terminal = Newtonsoft.Json.JsonConvert.DeserializeObject<AgentStreamChunk>(terminalJson!);
+            Assert.NotNull(terminal);
+            Assert.Equal(AgentChunkType.Error, terminal!.Type);
+            Assert.Equal(4, attempts);
+
+            var state = harness.GetHash(LlmAgentRedisKeys.AgentTaskState(task.TaskId));
+            Assert.Equal(AgentTaskStatus.Failed.ToString(), state["status"]);
+            Assert.Equal("3", state["transientRetryCount"]);
+        }
+
+        [Fact]
+        public async Task ProcessTaskAsync_NonTransientFailure_DoesNotRetry() {
+            var harness = new InMemoryRedisTestHarness();
+            var attempts = 0;
+            var executor = CreateExecutor((_, _, _) => FailOnceAsync(() => {
+                attempts++;
+                return new InvalidOperationException("model_not_found");
+            }));
+            var loop = CreateAgentLoop(harness, executor, _ => TimeSpan.Zero);
+            var task = CreateExecutionTask();
+
+            await loop.ProcessTaskAsync(task, "payload", task.ChatId, string.Empty, CancellationToken.None);
+
+            var terminalJson = harness.GetString(LlmAgentRedisKeys.AgentTerminal(task.TaskId));
+            Assert.NotNull(terminalJson);
+            var terminal = Newtonsoft.Json.JsonConvert.DeserializeObject<AgentStreamChunk>(terminalJson!);
+            Assert.NotNull(terminal);
+            Assert.Equal(AgentChunkType.Error, terminal!.Type);
+            Assert.Equal(1, attempts);
+
+            var state = harness.GetHash(LlmAgentRedisKeys.AgentTaskState(task.TaskId));
+            Assert.Equal(AgentTaskStatus.Failed.ToString(), state["status"]);
+            Assert.Equal("0", state["transientRetryCount"]);
+        }
+
         private static DataDbContext CreateDbContext() {
             var options = new DbContextOptionsBuilder<DataDbContext>()
                 .UseInMemoryDatabase($"AgentIntegrationTests_{Guid.NewGuid():N}")
@@ -235,7 +313,10 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
                 Mock.Of<ILogger<AgentRegistryService>>());
         }
 
-        private static AgentLoopService CreateAgentLoop(InMemoryRedisTestHarness harness, IAgentTaskExecutor executor) {
+        private static AgentLoopService CreateAgentLoop(
+            InMemoryRedisTestHarness harness,
+            IAgentTaskExecutor executor,
+            Func<int, TimeSpan>? retryDelayFactory = null) {
             var services = new ServiceCollection();
             services.AddScoped<IAgentTaskExecutor>(_ => executor);
             var provider = services.BuildServiceProvider();
@@ -243,7 +324,8 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
                 provider,
                 new GarnetClient(harness.Connection.Object),
                 new GarnetRpcClient(harness.Connection.Object),
-                Mock.Of<ILogger<AgentLoopService>>());
+                Mock.Of<ILogger<AgentLoopService>>(),
+                retryDelayFactory);
         }
 
         private static Telegram.Bot.Types.Message CreateTelegramMessage(long chatId, int messageId, long userId, string text) {
@@ -276,11 +358,50 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
             return new FakeAgentTaskExecutor(handler);
         }
 
+        private static AgentExecutionTask CreateExecutionTask() {
+            return new AgentExecutionTask {
+                TaskId = Guid.NewGuid().ToString("N"),
+                ChatId = -9001,
+                UserId = 1,
+                MessageId = 42,
+                BotUserId = 999,
+                BotName = "bot",
+                InputMessage = "hello",
+                ModelName = "test-model",
+                Channel = new AgentChannelConfig {
+                    ChannelId = 1,
+                    Name = "test",
+                    Gateway = "https://example.invalid",
+                    ApiKey = "key",
+                    Provider = LLMProvider.OpenAI,
+                    ModelName = "test-model"
+                }
+            };
+        }
+
         private static async IAsyncEnumerable<string> YieldSnapshotsAsync(params string[] snapshots) {
             foreach (var snapshot in snapshots) {
                 yield return snapshot;
                 await Task.Yield();
             }
+        }
+
+        private static async IAsyncEnumerable<string> ExecuteWithTransientOverloadAsync(
+            Func<bool> shouldFail,
+            string errorMessage,
+            string successSnapshot) {
+            await Task.Yield();
+            if (shouldFail()) {
+                throw new Exception(errorMessage);
+            }
+
+            yield return successSnapshot;
+        }
+
+        private static async IAsyncEnumerable<string> FailOnceAsync(Func<Exception> exceptionFactory) {
+            await Task.Yield();
+            throw exceptionFactory();
+            yield break;
         }
     }
 }


### PR DESCRIPTION
## Summary
- retry AI agent executions when providers return transient overload signals like HTTP 529 and overloaded_error
- use exponential backoff in AgentLoopService and reuse recovery suppression so retried runs do not replay duplicate snapshots
- add integration tests covering successful retry, retry exhaustion, and non-transient failures

## Validation
- dotnet build TelegramSearchBot.sln -c Release
- dotnet test TelegramSearchBot.sln -c Release --no-build