### PR TITLE
docs: add global PR workflow instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -35,6 +35,15 @@
 - 向量相关快速回归：`pwsh TelegramSearchBot.Test/RunVectorTests.ps1` 会筛选 `Category=Vector`。
 - `dotnet watch run --project TelegramSearchBot` 可本地监听重载，但注意并行子进程仍会启动。
 
+## 默认 PR 工作流
+- 默认按完整仓库工作流处理：先同步最新 `origin/master`，再从更新后的 `master` 新建分支；只有用户明确要求复用现有分支或继续当前 PR 时才例外。
+- 实现需求时保持改动聚焦，并运行与改动范围相关的现有验证命令。
+- 完成后默认推送分支并创建或更新 PR。
+- 必须检查 PR 的 CI 状态；如果有失败，读取失败 job 日志，修复问题后继续推送更新。
+- 必须检查 PR 对话、review comments 和相关讨论；如果反馈要求代码改动，应直接修改并更新 PR，而不只是文字回复。
+- 如果因权限不足、外部服务异常或需求不明确而受阻，需要明确说明阻塞原因。
+- 该工作流完成后，使用 `ask_user` 工具询问用户下一步要做什么。
+
 ## 开发提示
 - 所有持久化配置改动需更新 `Docs/README_VectorDatabaseInit.md` 或相关指南，保持用户文档同步。
 - 在管线中共享对象使用 `PipelineContext.PipelineCache`，不要通过静态变量跨控制器传递引用。

--- a/.github/prompts/pr-workflow.prompt.md
+++ b/.github/prompts/pr-workflow.prompt.md
@@ -1,0 +1,28 @@
+---
+description: "Sync latest master, work on a fresh branch, create or update a PR, inspect CI and PR feedback, then ask the user what to do next."
+---
+
+# PR workflow
+
+Use this prompt for end-to-end repository work that should start from the latest `origin/master` on a new branch and finish with a PR update.
+
+## Inputs
+
+- Requested work: ${input:task:Describe the bug, feature, PR refresh, or other work item to handle}
+- Related issue or PR: ${input:reference:Optional issue/PR URL, number, or extra GitHub context}
+
+## Workflow
+
+1. Sync the latest `origin/master` and create a fresh working branch from updated `master` unless the user explicitly asks to reuse an existing branch or continue on an existing PR branch.
+2. Investigate the requested work, make the necessary code or documentation changes, and keep the scope limited to the task.
+3. Run the repository's existing validation commands that are relevant to the touched area.
+4. Push the branch and create or update the pull request.
+5. Inspect the PR's CI status. If any check fails, read the failing job logs, fix the reported problems, and push follow-up commits.
+6. Review the PR conversation, review comments, and related discussion. If they call for targeted code changes, make those changes and update the PR instead of only replying in text.
+7. After the work is complete, use the `ask_user` tool to ask the user what they want done next.
+
+## Additional guidance
+
+- Prefer a clean branch from latest `master` for new work.
+- If the task is blocked by missing permissions, an external outage, or ambiguous requirements, explain the blocker clearly.
+- Do not skip the CI/log review or the PR discussion review when this workflow is invoked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,15 @@ pwsh TelegramSearchBot.Test/RunVectorTests.ps1
 dotnet publish -r win-x64 --self-contained
 ```
 
+## DEFAULT PR WORKFLOW
+- Unless the user explicitly asks to reuse an existing branch or continue an existing PR branch, sync the latest `origin/master` first and create a fresh branch from updated `master`.
+- Investigate and implement only the requested scope, then run the existing validation commands relevant to the touched area.
+- Push the branch and create or update the pull request as the default end-to-end flow.
+- Always inspect PR CI status. If a check fails, read the failing job logs, fix the reported issue, and push follow-up commits.
+- Always inspect the PR conversation, review comments, and related discussion. If feedback requires code changes, make those changes and update the PR instead of only replying in text.
+- If work is blocked by missing permissions, an external outage, or ambiguous requirements, state the blocker clearly.
+- After the workflow is complete, use the `ask_user` tool to ask what to do next.
+
 ## Development Notes
 - **Platform**: Windows primary, Linux partial (OCR/ASR limited)
 - **Config**: `%LOCALAPPDATA%/TelegramSearchBot/Config.json` - DO NOT use appsettings.json


### PR DESCRIPTION
## Summary
- add the PR workflow guidance to global Copilot instructions
- mirror the same default workflow in CLAUDE.md
- keep the standalone PR workflow prompt file available as an explicit entry point

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development workflow documentation and configuration guidelines.

---

**Note:** This release contains no user-facing changes. Updates are limited to internal development process documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->