### PR TITLE
feat: collapse prior llm agent iterations

### DIFF
--- a/TelegramSearchBot.Test/Helper/MessageFormatHelperTests.cs
+++ b/TelegramSearchBot.Test/Helper/MessageFormatHelperTests.cs
@@ -1,0 +1,61 @@
+using TelegramSearchBot.Helper;
+using Xunit;
+
+namespace TelegramSearchBot.Test.Helper {
+    public class MessageFormatHelperTests {
+        [Fact]
+        public void CollapseLlmIntermediateIterations_WithoutToolCall_KeepsOriginalText() {
+            var input = "这是一次直接回答，没有工具调用。";
+
+            var result = MessageFormatHelper.CollapseLlmIntermediateIterations(input);
+
+            Assert.Equal(input, result);
+        }
+
+        [Fact]
+        public void CollapseLlmIntermediateIterations_WithoutVisibleFinalIteration_KeepsOriginalText() {
+            var input = "前置分析\n\n🔧 `search_messages` [query: test]\n\n";
+
+            var result = MessageFormatHelper.CollapseLlmIntermediateIterations(input);
+
+            Assert.Equal(input, result);
+        }
+
+        [Fact]
+        public void CollapseLlmIntermediateIterations_WithFinalIteration_CollapsesPrefixOnly() {
+            var input = """
+第一轮分析
+
+🔧 `search_messages` [query: telegram collapse]
+
+最终回答：可以把中间过程折叠起来。
+""";
+
+            var result = MessageFormatHelper.CollapseLlmIntermediateIterations(input);
+
+            Assert.Contains(":::tg-expandable-blockquote", result);
+            Assert.Contains("第一轮分析", result);
+            Assert.Contains("🔧 `search_messages` [query: telegram collapse]", result);
+            Assert.EndsWith("最终回答：可以把中间过程折叠起来。", result);
+        }
+
+        [Fact]
+        public void ConvertMarkdownToTelegramHtml_WithCollapsedIterations_EmitsExpandableBlockquote() {
+            var markdown = """
+:::tg-expandable-blockquote
+第一轮分析
+
+🔧 `search_messages` [query: telegram collapse]
+:::
+
+最终回答：可以把中间过程折叠起来。
+""";
+
+            var html = MessageFormatHelper.ConvertMarkdownToTelegramHtml(markdown);
+
+            Assert.Contains("<blockquote expandable>", html);
+            Assert.Contains("<code>search_messages</code>", html);
+            Assert.Contains("最终回答：可以把中间过程折叠起来。", html);
+        }
+    }
+}

--- a/TelegramSearchBot/Helper/MessageFormatHelper.cs
+++ b/TelegramSearchBot/Helper/MessageFormatHelper.cs
@@ -9,6 +9,11 @@ using Markdig;
 
 namespace TelegramSearchBot.Helper {
     public static class MessageFormatHelper {
+        private const string ExpandableBlockquoteContainerClass = "tg-expandable-blockquote";
+        private static readonly Regex ToolCallDisplayRegex = new(
+            @"(?:\r?\n){2}🔧 `[^`\r\n]+`(?: \[[^\r\n]*\])?(?:\r?\n){2}",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
         public static string ConvertMarkdownToTelegramHtml(string markdownText) {
             if (string.IsNullOrEmpty(markdownText)) return string.Empty;
             var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UsePipeTables().Build();
@@ -56,14 +61,20 @@ namespace TelegramSearchBot.Helper {
                         case "h1": case "h2": case "h3": case "h4": case "h5": case "h6": builder.Append("<b>"); ProcessChildren(node, builder); builder.Append("</b>\n"); break;
                         case "ul": case "ol": ProcessList(node, builder, tagName == "ol" ? 1 : 0); builder.Append("\n"); break;
                         case "blockquote":
-                            var blockquoteContent = new StringBuilder(); ProcessChildren(node, blockquoteContent);
-                            var lines = blockquoteContent.ToString().Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries);
-                            foreach (var line in lines) builder.Append($"> {line}\n");
+                            builder.Append(node.Attributes["expandable"] != null ? "<blockquote expandable>" : "<blockquote>");
+                            ProcessChildren(node, builder);
+                            builder.Append("</blockquote>");
                             break;
                         case "span":
                         case "div":
                         case "font":
                         case "img":
+                            if (tagName == "div" && HasCssClass(node, ExpandableBlockquoteContainerClass)) {
+                                builder.Append("<blockquote expandable>");
+                                ProcessChildren(node, builder);
+                                builder.Append("</blockquote>");
+                                break;
+                            }
                             if (tagName == "img") {
                                 string alt = node.GetAttributeValue("alt", null); string src = node.GetAttributeValue("src", null);
                                 if (!string.IsNullOrEmpty(alt)) builder.Append($"[Image: {HttpUtility.HtmlEncode(alt)}] ");
@@ -80,6 +91,17 @@ namespace TelegramSearchBot.Helper {
 
         private static void ProcessChildren(HtmlNode parentNode, StringBuilder builder) {
             foreach (var childNode in parentNode.ChildNodes) ProcessHtmlNode(childNode, builder);
+        }
+
+        private static bool HasCssClass(HtmlNode node, string cssClass) {
+            var classValue = node.GetAttributeValue("class", string.Empty);
+            if (string.IsNullOrWhiteSpace(classValue)) {
+                return false;
+            }
+
+            return classValue
+                .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                .Any(x => string.Equals(x, cssClass, StringComparison.Ordinal));
         }
 
         private static void ProcessList(HtmlNode listNode, StringBuilder builder, int startNumber) {
@@ -212,6 +234,37 @@ namespace TelegramSearchBot.Helper {
                 chunks.Add(chunk); currentPosition += lengthToTake;
             }
             return chunks;
+        }
+
+        public static string CollapseLlmIntermediateIterations(string markdown) {
+            if (string.IsNullOrWhiteSpace(markdown)) {
+                return markdown ?? string.Empty;
+            }
+
+            var matches = ToolCallDisplayRegex.Matches(markdown);
+            if (matches.Count == 0) {
+                return markdown;
+            }
+
+            var lastMatch = matches[^1];
+            var suffixStart = lastMatch.Index + lastMatch.Length;
+            if (suffixStart >= markdown.Length) {
+                return markdown;
+            }
+
+            var collapsedPrefix = markdown[..suffixStart].TrimEnd();
+            var visibleSuffix = markdown[suffixStart..].TrimStart('\r', '\n');
+            if (string.IsNullOrWhiteSpace(collapsedPrefix) || string.IsNullOrWhiteSpace(visibleSuffix)) {
+                return markdown;
+            }
+
+            return $"""
+:::{ExpandableBlockquoteContainerClass}
+{collapsedPrefix}
+:::
+
+{visibleSuffix}
+""";
         }
 
         public static string EscapeMarkdownV2(string text) {

--- a/TelegramSearchBot/Service/BotAPI/SendMessageService.Streaming.cs
+++ b/TelegramSearchBot/Service/BotAPI/SendMessageService.Streaming.cs
@@ -149,13 +149,15 @@ namespace TelegramSearchBot.Service.BotAPI {
                     lastApiSyncTime = DateTime.UtcNow;
                     isFirstSync = false;
 
+                    var displayMarkdown = MessageFormatHelper.CollapseLlmIntermediateIterations(latestMarkdownSnapshot);
+                    var displayChunks = MessageFormatHelper.SplitMarkdownIntoChunks(displayMarkdown, 1900);
                     chunksForDb = MessageFormatHelper.SplitMarkdownIntoChunks(latestMarkdownSnapshot, 1900);
                     if (!chunksForDb.Any() && !string.IsNullOrEmpty(latestMarkdownSnapshot)) {
                         chunksForDb.Add(string.Empty);
                     }
 
                     var syncResult = await SynchronizeTelegramMessagesInternalAsync(
-                        chatId, replyTo, chunksForDb, sentTelegramMessages, lastSentHtmlPerMessageId, cancellationToken
+                        chatId, replyTo, displayChunks, sentTelegramMessages, lastSentHtmlPerMessageId, cancellationToken
                     );
                     sentTelegramMessages = syncResult.UpdatedMessages;
                     lastSentHtmlPerMessageId = syncResult.UpdatedHtmlMap;
@@ -168,11 +170,13 @@ namespace TelegramSearchBot.Service.BotAPI {
 
             if (latestMarkdownSnapshot != null && ( latestMarkdownSnapshot != markdownActuallySynced || !lastSyncComplete )) {
                 logger.LogInformation("SendFullMessageStream: Performing final synchronization for the absolute latest content.");
+                var displayMarkdown = MessageFormatHelper.CollapseLlmIntermediateIterations(latestMarkdownSnapshot);
+                var displayChunks = MessageFormatHelper.SplitMarkdownIntoChunks(displayMarkdown, 1900);
                 chunksForDb = MessageFormatHelper.SplitMarkdownIntoChunks(latestMarkdownSnapshot, 1900);
                 if (!chunksForDb.Any() && !string.IsNullOrEmpty(latestMarkdownSnapshot)) chunksForDb.Add(string.Empty);
 
                 var syncResult = await SynchronizeTelegramMessagesInternalAsync(
-                       chatId, replyTo, chunksForDb, sentTelegramMessages, lastSentHtmlPerMessageId, CancellationToken.None);
+                       chatId, replyTo, displayChunks, sentTelegramMessages, lastSentHtmlPerMessageId, CancellationToken.None);
                 sentTelegramMessages = syncResult.UpdatedMessages;
             } else if (latestMarkdownSnapshot == null && sentTelegramMessages.Any()) {
                 logger.LogInformation("SendFullMessageStream: Stream ended with no content, clearing existing messages.");
@@ -396,7 +400,8 @@ namespace TelegramSearchBot.Service.BotAPI {
 
                     // Convert markdown to HTML and send as draft update
                     try {
-                        var html = MessageFormatHelper.ConvertMarkdownToTelegramHtml(latestContent);
+                        var displayMarkdown = MessageFormatHelper.CollapseLlmIntermediateIterations(latestContent);
+                        var html = MessageFormatHelper.ConvertMarkdownToTelegramHtml(displayMarkdown);
                         if (!string.IsNullOrWhiteSpace(html)) {
                             await botClient.SendMessageDraft(chatId, draftId, html, parseMode: ParseMode.Html, cancellationToken: cancellationToken);
                         }
@@ -413,7 +418,8 @@ namespace TelegramSearchBot.Service.BotAPI {
             // Final sync: ensure the latest content is sent
             if (latestContent != null) {
                 try {
-                    var finalHtml = MessageFormatHelper.ConvertMarkdownToTelegramHtml(latestContent);
+                    var displayMarkdown = MessageFormatHelper.CollapseLlmIntermediateIterations(latestContent);
+                    var finalHtml = MessageFormatHelper.ConvertMarkdownToTelegramHtml(displayMarkdown);
                     if (!string.IsNullOrWhiteSpace(finalHtml)) {
                         await botClient.SendMessageDraft(chatId, draftId, finalHtml, parseMode: ParseMode.Html, cancellationToken: CancellationToken.None);
                     }


### PR DESCRIPTION
## Summary
- collapse all accumulated agent output before the latest iteration into a Telegram expandable blockquote
- preserve the latest iteration as normal visible content during LLM streaming
- add tests for collapse detection and Telegram HTML conversion