### PR TITLE
fix: avoid double-escaping code block output

### DIFF
--- a/TelegramSearchBot.Test/Helper/MessageFormatHelperTests.cs
+++ b/TelegramSearchBot.Test/Helper/MessageFormatHelperTests.cs
@@ -57,5 +57,21 @@ namespace TelegramSearchBot.Test.Helper {
             Assert.Contains("<code>search_messages</code>", html);
             Assert.Contains("最终回答：可以把中间过程折叠起来。", html);
         }
+
+        [Fact]
+        public void ConvertMarkdownToTelegramHtml_WithCodeBlock_DoesNotDoubleEscapeEntities() {
+            var markdown = """
+```text
+功能丰富度: PostgreSQL > MySQL & MariaDB
+```
+""";
+
+            var html = MessageFormatHelper.ConvertMarkdownToTelegramHtml(markdown);
+
+            Assert.Contains("&gt;", html);
+            Assert.Contains("&amp;", html);
+            Assert.DoesNotContain("&amp;gt;", html);
+            Assert.DoesNotContain("&amp;amp;", html);
+        }
     }
 }

--- a/TelegramSearchBot/Helper/MessageFormatHelper.cs
+++ b/TelegramSearchBot/Helper/MessageFormatHelper.cs
@@ -44,14 +44,14 @@ namespace TelegramSearchBot.Helper {
                                 string langClass = node.GetAttributeValue("class", "");
                                 if (!string.IsNullOrEmpty(langClass) && langClass.StartsWith("language-")) builder.Append($"<code class=\"{HttpUtility.HtmlEncode(langClass)}\">");
                                 else builder.Append("<code>");
-                                builder.Append(HttpUtility.HtmlEncode(node.InnerText));
+                                builder.Append(EncodeTelegramHtmlText(node.InnerText));
                                 builder.Append("</code>");
-                            } else { builder.Append("<code>"); builder.Append(HttpUtility.HtmlEncode(node.InnerText)); builder.Append("</code>"); }
+                            } else { builder.Append("<code>"); builder.Append(EncodeTelegramHtmlText(node.InnerText)); builder.Append("</code>"); }
                             break;
                         case "pre":
                             builder.Append("<pre>");
                             if (node.ChildNodes.Count == 1 && node.FirstChild.Name.ToLowerInvariant() == "code") ProcessHtmlNode(node.FirstChild, builder);
-                            else builder.Append(HttpUtility.HtmlEncode(node.InnerText));
+                            else builder.Append(EncodeTelegramHtmlText(node.InnerText));
                             builder.Append("</pre>");
                             break;
                         case "table": builder.Append(FormatHtmlTableAsPreformattedText(node)); break;
@@ -102,6 +102,10 @@ namespace TelegramSearchBot.Helper {
             return classValue
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries)
                 .Any(x => string.Equals(x, cssClass, StringComparison.Ordinal));
+        }
+
+        private static string EncodeTelegramHtmlText(string text) {
+            return HttpUtility.HtmlEncode(HttpUtility.HtmlDecode(text ?? string.Empty));
         }
 
         private static void ProcessList(HtmlNode listNode, StringBuilder builder, int startNumber) {


### PR DESCRIPTION
## Summary
- stop double-encoding HTML entities inside rendered code blocks and inline code
- reuse the same decode-then-encode path used for normal text nodes
- add regression coverage for fenced code block output