### PR TITLE
fix: correct PR report test status

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,56 +61,118 @@ jobs:
     if: always() && github.event_name == 'pull_request'
     
     steps:
-    - name: Download all test results
-      uses: actions/download-artifact@v4
-    
     - name: Generate PR report
-      run: |
-        echo "# 🔍 PR检查报告" > pr-report.md
-        echo "" >> pr-report.md
-        echo "## 📋 检查概览" >> pr-report.md
-        echo "- **PR**: #${{ github.event.number }}" >> pr-report.md
-        echo "- **分支**: ${{ github.event.pull_request.head.ref }} → ${{ github.event.pull_request.base.ref }}" >> pr-report.md
-        echo "- **触发事件**: ${{ github.event_name }}" >> pr-report.md
-        echo "- **提交**: ${{ github.sha }}" >> pr-report.md
-        echo "" >> pr-report.md
-        
-        echo "## 🧪 测试结果" >> pr-report.md
-        echo "| 平台 | 状态 | 详情 |" >> pr-report.md
-        echo "|------|------|------|" >> pr-report.md
-        
-        if [ -d "test-results-ubuntu-latest" ]; then
-          echo "| Ubuntu | 🟢 已完成 | 查看测试结果 |" >> pr-report.md
-        else
-          echo "| Ubuntu | 🔴 失败 | 测试结果不可用 |" >> pr-report.md
-        fi
-        
-        if [ -d "test-results-windows-latest" ]; then
-          echo "| Windows | 🟢 已完成 | 查看测试结果 |" >> pr-report.md
-        else
-          echo "| Windows | 🔴 失败 | 测试结果不可用 |" >> pr-report.md
-        fi
-        echo "" >> pr-report.md
-        
-        echo "## 📊 代码质量" >> pr-report.md
-        echo "- ✅ 代码格式化检查" >> pr-report.md
-        echo "- ✅ 安全漏洞扫描" >> pr-report.md
-        echo "- ✅ 依赖包分析" >> pr-report.md
-        echo "- ✅ 代码覆盖率收集" >> pr-report.md
-        echo "" >> pr-report.md
-        
-        echo "## 📁 测试产物" >> pr-report.md
-        echo "- 测试结果文件已上传为artifacts" >> pr-report.md
-        echo "- 代码覆盖率已上传到Codecov" >> pr-report.md
-        echo "" >> pr-report.md
-        
-        echo "## 🔗 相关链接" >> pr-report.md
-        echo "- [PR页面](${{ github.event.pull_request.html_url }})" >> pr-report.md
-        echo "- [Actions日志](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" >> pr-report.md
-        echo "" >> pr-report.md
-        
-        echo "---" >> pr-report.md
-        echo "*此报告由GitHub Actions自动生成*" >> pr-report.md
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require('fs');
+
+          const owner = context.repo.owner;
+          const repo = context.repo.repo;
+          const runId = context.runId;
+
+          const { data: jobsResponse } = await github.rest.actions.listJobsForWorkflowRun({
+            owner,
+            repo,
+            run_id: runId,
+            per_page: 100
+          });
+
+          const { data: artifactsResponse } = await github.rest.actions.listWorkflowRunArtifacts({
+            owner,
+            repo,
+            run_id: runId,
+            per_page: 100
+          });
+
+          const artifactNames = new Set((artifactsResponse.artifacts || []).map(artifact => artifact.name));
+          const jobs = jobsResponse.jobs || [];
+
+          function findJob(osName) {
+            return jobs.find(job => job.name === `build (${osName})`);
+          }
+
+          function formatPlatformRow(label, osName) {
+            const job = findJob(osName);
+            if (!job) {
+              return `| ${label} | ⚪ 未知 | 未找到对应 job |`;
+            }
+
+            const testStep = (job.steps || []).find(step => step.name === 'Test');
+            const buildStep = (job.steps || []).find(step => step.name === 'Build');
+            const uploadStep = (job.steps || []).find(step => step.name === 'Upload test results');
+            const artifactName = `test-results-${osName}`;
+            const hasArtifact = artifactNames.has(artifactName);
+            const jobLink = job.html_url;
+
+            if (job.conclusion === 'success') {
+              let detail = '构建与测试通过';
+              if (testStep?.conclusion === 'success' && hasArtifact) {
+                detail = '测试通过，产物已上传';
+              } else if (testStep?.conclusion === 'success') {
+                detail = '测试通过，未检测到测试产物';
+              }
+
+              return `| ${label} | 🟢 成功 | [${detail}](${jobLink}) |`;
+            }
+
+            if (testStep?.conclusion === 'failure') {
+              return `| ${label} | 🔴 失败 | [测试步骤失败](${jobLink}) |`;
+            }
+
+            if (buildStep?.conclusion === 'failure') {
+              return `| ${label} | 🔴 失败 | [构建步骤失败](${jobLink}) |`;
+            }
+
+            if (uploadStep?.conclusion === 'failure') {
+              return `| ${label} | 🟡 异常 | [测试产物上传失败](${jobLink}) |`;
+            }
+
+            if (job.conclusion === 'cancelled') {
+              return `| ${label} | ⚪ 已取消 | [Job 已取消](${jobLink}) |`;
+            }
+
+            if (job.status !== 'completed') {
+              return `| ${label} | 🟡 进行中 | [Job 仍在运行](${jobLink}) |`;
+            }
+
+            return `| ${label} | 🟡 异常 | [结论: ${job.conclusion || 'unknown'}](${jobLink}) |`;
+          }
+
+          const reportLines = [
+            '# 🔍 PR检查报告',
+            '',
+            '## 📋 检查概览',
+            `- **PR**: #${context.payload.pull_request.number}`,
+            `- **分支**: ${context.payload.pull_request.head.ref} → ${context.payload.pull_request.base.ref}`,
+            `- **触发事件**: ${context.eventName}`,
+            `- **提交**: ${context.sha}`,
+            '',
+            '## 🧪 测试结果',
+            '| 平台 | 状态 | 详情 |',
+            '|------|------|------|',
+            formatPlatformRow('Ubuntu', 'ubuntu-latest'),
+            formatPlatformRow('Windows', 'windows-latest'),
+            '',
+            '## 📊 代码质量',
+            '- ✅ 代码格式化检查',
+            '- ✅ 安全漏洞扫描',
+            '- ✅ 依赖包分析',
+            '- ✅ 代码覆盖率收集',
+            '',
+            '## 📁 测试产物',
+            `- 测试结果 artifacts 数量: ${artifactNames.size}`,
+            '- 代码覆盖率已上传到Codecov',
+            '',
+            '## 🔗 相关链接',
+            `- [PR页面](${context.payload.pull_request.html_url})`,
+            `- [Actions日志](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${runId})`,
+            '',
+            '---',
+            '*此报告由GitHub Actions自动生成*'
+          ];
+
+          fs.writeFileSync('pr-report.md', `${reportLines.join('\n')}\n`, 'utf8');
     
     - name: Find existing comment
       if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,13 +38,13 @@ jobs:
       run: dotnet list package --vulnerable --include-transitive
     
     - name: Test
-      run: dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage"
+      run: dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage" --logger "trx;LogFileName=test-results.trx"
     
     - name: Upload coverage to Codecov
       if: matrix.os == 'windows-latest'
       uses: codecov/codecov-action@v5
       with:
-        file: ./TestResults/**/*.xml
+        file: ./**/TestResults/**/*.xml
         flags: pr-check
         name: pr-${{ github.event.number }}-${{ matrix.os }}
     
@@ -53,7 +53,10 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: test-results-${{ matrix.os }}
-        path: TestResults/
+        path: |
+          **/TestResults/**/*.trx
+          **/TestResults/**/*.xml
+        if-no-files-found: error
 
   report:
     needs: build


### PR DESCRIPTION
## Summary
- stop inferring test status from downloaded artifact directories in the PR report job
- derive Ubuntu and Windows status from the actual workflow job and step conclusions
- report successful test runs accurately even when no test artifact is present