### PR TITLE
feat: add persistent todo reminders

### DIFF
--- a/TelegramSearchBot.Common/Model/Tools/TodoItemResult.cs
+++ b/TelegramSearchBot.Common/Model/Tools/TodoItemResult.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace TelegramSearchBot.Model.Tools {
+    public class TodoToolItem {
+        public long TodoId { get; set; }
+        public long ChatId { get; set; }
+        public string ListName { get; set; } = null!;
+        public string Title { get; set; } = null!;
+        public string Description { get; set; } = string.Empty;
+        public string Priority { get; set; } = string.Empty;
+        public string Status { get; set; } = null!;
+        public DateTime CreatedAtUtc { get; set; }
+        public DateTime? DueAtUtc { get; set; }
+        public DateTime? RemindAtUtc { get; set; }
+        public DateTime? ReminderSentAtUtc { get; set; }
+        public DateTime? CompletedAtUtc { get; set; }
+        public long? SourceMessageId { get; set; }
+    }
+
+    public class TodoItemResult {
+        public bool Success { get; set; }
+        public long ChatId { get; set; }
+        public long? TodoId { get; set; }
+        public string Error { get; set; } = string.Empty;
+        public string Note { get; set; } = string.Empty;
+        public TodoToolItem? Todo { get; set; }
+    }
+
+    public class TodoQueryResult {
+        public long ChatId { get; set; }
+        public string ListName { get; set; } = string.Empty;
+        public string StatusFilter { get; set; } = string.Empty;
+        public int TotalCount { get; set; }
+        public int CurrentPage { get; set; }
+        public int PageSize { get; set; }
+        public string Note { get; set; } = string.Empty;
+        public List<TodoToolItem> Items { get; set; } = new();
+    }
+
+    public class TodoCompletionResult {
+        public bool Success { get; set; }
+        public long ChatId { get; set; }
+        public long TodoId { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public string Error { get; set; } = string.Empty;
+        public string Note { get; set; } = string.Empty;
+        public DateTime? CompletedAtUtc { get; set; }
+        public TodoToolItem? Todo { get; set; }
+    }
+}

--- a/TelegramSearchBot.Database/Migrations/20260422075450_AddTodoReminderTables.Designer.cs
+++ b/TelegramSearchBot.Database/Migrations/20260422075450_AddTodoReminderTables.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TelegramSearchBot.Model;
 
@@ -10,9 +11,11 @@ using TelegramSearchBot.Model;
 namespace TelegramSearchBot.Migrations
 {
     [DbContext(typeof(DataDbContext))]
-    partial class DataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260422075450_AddTodoReminderTables")]
+    partial class AddTodoReminderTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.3");

--- a/TelegramSearchBot.Database/Migrations/20260422075450_AddTodoReminderTables.cs
+++ b/TelegramSearchBot.Database/Migrations/20260422075450_AddTodoReminderTables.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelegramSearchBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTodoReminderTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "TodoLists",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ChatId = table.Column<long>(type: "INTEGER", nullable: false),
+                    Name = table.Column<string>(type: "TEXT", maxLength: 100, nullable: false),
+                    CreatedBy = table.Column<long>(type: "INTEGER", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TodoLists", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "TodoItems",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    ChatId = table.Column<long>(type: "INTEGER", nullable: false),
+                    TodoListId = table.Column<long>(type: "INTEGER", nullable: false),
+                    Title = table.Column<string>(type: "TEXT", maxLength: 200, nullable: false),
+                    Description = table.Column<string>(type: "TEXT", maxLength: 2000, nullable: true),
+                    Priority = table.Column<string>(type: "TEXT", maxLength: 20, nullable: true),
+                    Status = table.Column<string>(type: "TEXT", maxLength: 20, nullable: false),
+                    CreatedBy = table.Column<long>(type: "INTEGER", nullable: false),
+                    CompletedBy = table.Column<long>(type: "INTEGER", nullable: true),
+                    SourceMessageId = table.Column<long>(type: "INTEGER", nullable: true),
+                    ReminderMessageId = table.Column<long>(type: "INTEGER", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    UpdatedAt = table.Column<DateTime>(type: "TEXT", nullable: false),
+                    DueAtUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    RemindAtUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    ReminderSentAtUtc = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    CompletedAtUtc = table.Column<DateTime>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_TodoItems", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_TodoItems_TodoLists_TodoListId",
+                        column: x => x.TodoListId,
+                        principalTable: "TodoLists",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TodoItems_ChatId_Status_RemindAtUtc_ReminderSentAtUtc",
+                table: "TodoItems",
+                columns: new[] { "ChatId", "Status", "RemindAtUtc", "ReminderSentAtUtc" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TodoItems_TodoListId_Status",
+                table: "TodoItems",
+                columns: new[] { "TodoListId", "Status" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_TodoLists_ChatId_Name",
+                table: "TodoLists",
+                columns: new[] { "ChatId", "Name" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "TodoItems");
+
+            migrationBuilder.DropTable(
+                name: "TodoLists");
+        }
+    }
+}

--- a/TelegramSearchBot.Database/Model/Data/TodoItem.cs
+++ b/TelegramSearchBot.Database/Model/Data/TodoItem.cs
@@ -1,0 +1,62 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Microsoft.EntityFrameworkCore;
+
+namespace TelegramSearchBot.Model.Data {
+    [Index(nameof(ChatId), nameof(Status), nameof(RemindAtUtc), nameof(ReminderSentAtUtc))]
+    [Index(nameof(TodoListId), nameof(Status))]
+    public class TodoItem {
+        [Key]
+        public long Id { get; set; }
+
+        [Required]
+        public long ChatId { get; set; }
+
+        [Required]
+        public long TodoListId { get; set; }
+
+        [ForeignKey(nameof(TodoListId))]
+        public TodoList TodoList { get; set; } = null!;
+
+        [Required]
+        [StringLength(200)]
+        public string Title { get; set; } = null!;
+
+        [StringLength(2000)]
+        public string Description { get; set; } = string.Empty;
+
+        [StringLength(20)]
+        public string Priority { get; set; } = string.Empty;
+
+        [Required]
+        [StringLength(20)]
+        public string Status { get; set; } = TodoItemStatus.Pending;
+
+        [Required]
+        public long CreatedBy { get; set; }
+
+        public long? CompletedBy { get; set; }
+
+        public long? SourceMessageId { get; set; }
+
+        public long? ReminderMessageId { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        public DateTime? DueAtUtc { get; set; }
+
+        public DateTime? RemindAtUtc { get; set; }
+
+        public DateTime? ReminderSentAtUtc { get; set; }
+
+        public DateTime? CompletedAtUtc { get; set; }
+    }
+
+    public static class TodoItemStatus {
+        public const string Pending = "Pending";
+        public const string Completed = "Completed";
+    }
+}

--- a/TelegramSearchBot.Database/Model/Data/TodoList.cs
+++ b/TelegramSearchBot.Database/Model/Data/TodoList.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using Microsoft.EntityFrameworkCore;
+
+namespace TelegramSearchBot.Model.Data {
+    [Index(nameof(ChatId), nameof(Name), IsUnique = true)]
+    public class TodoList {
+        [Key]
+        public long Id { get; set; }
+
+        [Required]
+        public long ChatId { get; set; }
+
+        [Required]
+        [StringLength(100)]
+        public string Name { get; set; } = null!;
+
+        [Required]
+        public long CreatedBy { get; set; }
+
+        public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+        public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+        public virtual ICollection<TodoItem> Items { get; set; } = new List<TodoItem>();
+    }
+}

--- a/TelegramSearchBot.Database/Model/DataDbContext.cs
+++ b/TelegramSearchBot.Database/Model/DataDbContext.cs
@@ -67,6 +67,12 @@ namespace TelegramSearchBot.Model {
                 .HasForeignKey(ar => ar.AccountBookId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            modelBuilder.Entity<TodoItem>()
+                .HasOne(ti => ti.TodoList)
+                .WithMany(tl => tl.Items)
+                .HasForeignKey(ti => ti.TodoListId)
+                .OnDelete(DeleteBehavior.Cascade);
+
             // You can add other configurations here if needed
         }
         public virtual DbSet<Message> Messages { get; set; }
@@ -91,5 +97,7 @@ namespace TelegramSearchBot.Model {
         public virtual DbSet<AccountRecord> AccountRecords { get; set; } = null!;
         public virtual DbSet<GroupAccountSettings> GroupAccountSettings { get; set; } = null!;
         public virtual DbSet<ScheduledTaskExecution> ScheduledTaskExecutions { get; set; } = null!;
+        public virtual DbSet<TodoList> TodoLists { get; set; } = null!;
+        public virtual DbSet<TodoItem> TodoItems { get; set; } = null!;
     }
 }

--- a/TelegramSearchBot.Test/Service/Scheduler/TodoReminderTaskTests.cs
+++ b/TelegramSearchBot.Test/Service/Scheduler/TodoReminderTaskTests.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using TelegramSearchBot.Manager;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Service.Scheduler;
+using TelegramSearchBot.Service.Todo;
+using Xunit;
+
+namespace TelegramSearchBot.Test.Service.Scheduler {
+    public sealed class TodoReminderTaskTests {
+        [Fact]
+        public async Task ExecuteAsync_SendsDueReminderAndMarksTodoAsSent() {
+            var databaseName = $"TodoReminderTaskTests_{Guid.NewGuid():N}";
+            var services = new ServiceCollection();
+            services.AddDbContext<DataDbContext>(
+                options => options.UseInMemoryDatabase(databaseName),
+                ServiceLifetime.Transient);
+            services.AddTransient<TodoService>();
+
+            var serviceProvider = services.BuildServiceProvider();
+
+            await using (var scope = serviceProvider.CreateAsyncScope()) {
+                var todoService = scope.ServiceProvider.GetRequiredService<TodoService>();
+                await todoService.CreateTodoAsync(
+                    chatId: -100123,
+                    userId: 42,
+                    sourceMessageId: 10,
+                    title: "到点提醒",
+                    remindAt: DateTimeOffset.UtcNow.AddMinutes(-1).ToString("O"));
+            }
+
+            var botClientMock = new Mock<ITelegramBotClient>();
+            botClientMock.SetReturnsDefault(Task.FromResult(new Message {
+                Id = 888,
+                Date = DateTime.UtcNow,
+                Chat = new Chat {
+                    Id = -100123,
+                    Type = ChatType.Supergroup
+                }
+            }));
+
+            var sendMessage = new SendMessage(
+                botClientMock.Object,
+                Mock.Of<ILogger<SendMessage>>());
+
+            var task = new TodoReminderTask(
+                serviceProvider,
+                botClientMock.Object,
+                sendMessage,
+                Mock.Of<ILogger<TodoReminderTask>>());
+
+            await task.ExecuteAsync();
+
+            await using var verificationScope = serviceProvider.CreateAsyncScope();
+            var dbContext = verificationScope.ServiceProvider.GetRequiredService<DataDbContext>();
+            var todo = await dbContext.TodoItems.SingleAsync();
+            Assert.NotNull(todo.ReminderSentAtUtc);
+            Assert.Equal(888, todo.ReminderMessageId);
+        }
+    }
+}

--- a/TelegramSearchBot.Test/Service/Todo/TodoServiceTests.cs
+++ b/TelegramSearchBot.Test/Service/Todo/TodoServiceTests.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Model.Data;
+using TelegramSearchBot.Service.Todo;
+using Xunit;
+
+namespace TelegramSearchBot.Test.Service.Todo {
+    public sealed class TodoServiceTests : IDisposable {
+        private readonly DataDbContext _dbContext;
+        private readonly TodoService _todoService;
+
+        public TodoServiceTests() {
+            var options = new DbContextOptionsBuilder<DataDbContext>()
+                .UseInMemoryDatabase($"TodoServiceTests_{Guid.NewGuid():N}")
+                .Options;
+
+            _dbContext = new DataDbContext(options);
+            _dbContext.Database.EnsureCreated();
+            _todoService = new TodoService(_dbContext);
+        }
+
+        [Fact]
+        public async Task CreateTodoAsync_CreatesTodoInNamedList() {
+            var result = await _todoService.CreateTodoAsync(
+                chatId: -100123,
+                userId: 42,
+                sourceMessageId: 777,
+                title: "整理 PR #244",
+                listName: "工作",
+                description: "补全 todo / reminder / completion flow",
+                priority: "high",
+                dueAt: "2026-04-25T20:00:00+08:00",
+                remindAt: "2026-04-25T18:00:00+08:00");
+
+            Assert.True(result.Success);
+            Assert.NotNull(result.Todo);
+            Assert.NotNull(result.TodoId);
+            Assert.Equal("工作", result.Todo.ListName);
+            Assert.Equal(TodoItemStatus.Pending, result.Todo.Status);
+            Assert.Equal(1, await _dbContext.TodoLists.CountAsync());
+            Assert.Equal(1, await _dbContext.TodoItems.CountAsync());
+
+            var savedTodo = await _dbContext.TodoItems.Include(item => item.TodoList).SingleAsync();
+            Assert.Equal("整理 PR #244", savedTodo.Title);
+            Assert.Equal("工作", savedTodo.TodoList.Name);
+            Assert.NotNull(savedTodo.DueAtUtc);
+            Assert.NotNull(savedTodo.RemindAtUtc);
+            Assert.Null(savedTodo.ReminderSentAtUtc);
+        }
+
+        [Fact]
+        public async Task QueryTodosAsync_FiltersPendingItemsByList() {
+            await _todoService.CreateTodoAsync(-100123, 42, 1, "完成迁移", "工作", remindAt: "2026-04-25T10:00:00+08:00");
+            var completedTodo = await _todoService.CreateTodoAsync(-100123, 42, 2, "已完成事项", "工作");
+            await _todoService.CreateTodoAsync(-100123, 42, 3, "买牛奶", "生活");
+            await _todoService.CompleteTodoAsync(-100123, completedTodo.TodoId!.Value, 42);
+
+            var result = await _todoService.QueryTodosAsync(-100123, listName: "工作", statusFilter: "pending");
+
+            Assert.Equal(1, result.TotalCount);
+            Assert.Single(result.Items);
+            Assert.Equal("完成迁移", result.Items[0].Title);
+            Assert.Equal("工作", result.Items[0].ListName);
+            Assert.Equal(TodoItemStatus.Pending, result.Items[0].Status);
+        }
+
+        [Fact]
+        public async Task CompleteTodoAsync_MarksTodoCompleted() {
+            var created = await _todoService.CreateTodoAsync(-100123, 42, 5, "点击完成按钮");
+
+            var result = await _todoService.CompleteTodoAsync(-100123, created.TodoId!.Value, 1000);
+
+            Assert.True(result.Success);
+            Assert.Equal(TodoItemStatus.Completed, result.Status);
+            Assert.NotNull(result.CompletedAtUtc);
+
+            var savedTodo = await _dbContext.TodoItems.SingleAsync();
+            Assert.Equal(TodoItemStatus.Completed, savedTodo.Status);
+            Assert.Equal(1000, savedTodo.CompletedBy);
+            Assert.NotNull(savedTodo.CompletedAtUtc);
+        }
+
+        [Fact]
+        public async Task GetPendingRemindersAsync_ReturnsOnlyDueUnsentPendingTodos() {
+            var dueTodo = await _todoService.CreateTodoAsync(-100123, 42, 1, "需要提醒", remindAt: DateTimeOffset.UtcNow.AddMinutes(-5).ToString("O"));
+            await _todoService.CreateTodoAsync(-100123, 42, 2, "未来提醒", remindAt: DateTimeOffset.UtcNow.AddMinutes(10).ToString("O"));
+            var completedTodo = await _todoService.CreateTodoAsync(-100123, 42, 3, "已完成提醒", remindAt: DateTimeOffset.UtcNow.AddMinutes(-3).ToString("O"));
+            var sentTodo = await _todoService.CreateTodoAsync(-100123, 42, 4, "已发送提醒", remindAt: DateTimeOffset.UtcNow.AddMinutes(-2).ToString("O"));
+
+            await _todoService.CompleteTodoAsync(-100123, completedTodo.TodoId!.Value, 42);
+            await _todoService.MarkReminderSentAsync(sentTodo.TodoId!.Value, 999, DateTime.UtcNow.AddMinutes(-1));
+
+            var result = await _todoService.GetPendingRemindersAsync(DateTime.UtcNow);
+
+            Assert.Single(result);
+            Assert.Equal(dueTodo.TodoId, result[0].Id);
+            Assert.All(result, todo => Assert.Equal(TodoItemStatus.Pending, todo.Status));
+            Assert.All(result, todo => Assert.Null(todo.ReminderSentAtUtc));
+        }
+
+        public void Dispose() {
+            _dbContext.Dispose();
+        }
+    }
+}

--- a/TelegramSearchBot.Test/Service/Todo/TodoServiceTests.cs
+++ b/TelegramSearchBot.Test/Service/Todo/TodoServiceTests.cs
@@ -101,6 +101,51 @@ namespace TelegramSearchBot.Test.Service.Todo {
             Assert.All(result, todo => Assert.Null(todo.ReminderSentAtUtc));
         }
 
+        [Fact]
+        public async Task UpdateTodoAsync_UpdatesFieldsAndResetsReminderState() {
+            var created = await _todoService.CreateTodoAsync(
+                chatId: -100123,
+                userId: 42,
+                sourceMessageId: 10,
+                title: "初始标题",
+                listName: "工作",
+                description: "初始描述",
+                priority: "high",
+                dueAt: "2026-04-25T20:00:00+08:00",
+                remindAt: DateTimeOffset.UtcNow.AddMinutes(-5).ToString("O"));
+
+            await _todoService.MarkReminderSentAsync(created.TodoId!.Value, 999, DateTime.UtcNow.AddMinutes(-1));
+
+            var updated = await _todoService.UpdateTodoAsync(
+                chatId: -100123,
+                todoId: created.TodoId.Value,
+                updatedBy: 1000,
+                title: "修正后的标题",
+                listName: "生活",
+                description: "修正后的描述",
+                priority: "",
+                dueAt: "2026-04-26T21:30:00+08:00",
+                remindAt: DateTimeOffset.UtcNow.AddMinutes(30).ToString("O"));
+
+            Assert.True(updated.Success);
+            Assert.NotNull(updated.Todo);
+            Assert.Equal("修正后的标题", updated.Todo!.Title);
+            Assert.Equal("生活", updated.Todo.ListName);
+            Assert.Equal("修正后的描述", updated.Todo.Description);
+            Assert.Equal(string.Empty, updated.Todo.Priority);
+            Assert.Equal("Todo updated and reminder schedule refreshed.", updated.Note);
+
+            var savedTodo = await _dbContext.TodoItems.Include(item => item.TodoList).SingleAsync();
+            Assert.Equal("修正后的标题", savedTodo.Title);
+            Assert.Equal("生活", savedTodo.TodoList.Name);
+            Assert.Equal("修正后的描述", savedTodo.Description);
+            Assert.Equal(string.Empty, savedTodo.Priority);
+            Assert.NotNull(savedTodo.DueAtUtc);
+            Assert.NotNull(savedTodo.RemindAtUtc);
+            Assert.Null(savedTodo.ReminderSentAtUtc);
+            Assert.Null(savedTodo.ReminderMessageId);
+        }
+
         public void Dispose() {
             _dbContext.Dispose();
         }

--- a/TelegramSearchBot/Controller/Manage/TodoCallbackController.cs
+++ b/TelegramSearchBot/Controller/Manage/TodoCallbackController.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using TelegramSearchBot.Interface.Controller;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Service.Todo;
+
+namespace TelegramSearchBot.Controller.Manage {
+    public class TodoCallbackController : IOnUpdate {
+        private const string CompletePrefix = "todo_complete:";
+
+        private readonly ITelegramBotClient _botClient;
+        private readonly TodoService _todoService;
+        private readonly ILogger<TodoCallbackController> _logger;
+
+        public TodoCallbackController(
+            ITelegramBotClient botClient,
+            TodoService todoService,
+            ILogger<TodoCallbackController> logger) {
+            _botClient = botClient;
+            _todoService = todoService;
+            _logger = logger;
+        }
+
+        public List<Type> Dependencies => new();
+
+        public async Task ExecuteAsync(PipelineContext p) {
+            var callbackQuery = p.Update.CallbackQuery;
+            if (callbackQuery == null || string.IsNullOrWhiteSpace(callbackQuery.Data)) {
+                return;
+            }
+
+            if (!callbackQuery.Data.StartsWith(CompletePrefix, StringComparison.Ordinal)) {
+                return;
+            }
+
+            if (!long.TryParse(callbackQuery.Data.Substring(CompletePrefix.Length), out var todoId)) {
+                await _botClient.AnswerCallbackQuery(callbackQuery.Id, "无效的待办编号");
+                return;
+            }
+
+            var chatId = callbackQuery.Message?.Chat.Id ?? 0;
+            if (chatId == 0) {
+                await _botClient.AnswerCallbackQuery(callbackQuery.Id, "无法确认当前聊天");
+                return;
+            }
+
+            var result = await _todoService.CompleteTodoAsync(chatId, todoId, callbackQuery.From.Id);
+            if (!result.Success) {
+                await _botClient.AnswerCallbackQuery(callbackQuery.Id, result.Error);
+                return;
+            }
+
+            await _botClient.AnswerCallbackQuery(callbackQuery.Id, "已标记完成");
+
+            if (callbackQuery.Message == null) {
+                return;
+            }
+
+            try {
+                await _botClient.EditMessageReplyMarkup(
+                    chatId: callbackQuery.Message.Chat.Id,
+                    messageId: callbackQuery.Message.MessageId,
+                    replyMarkup: null);
+            } catch (Telegram.Bot.Exceptions.ApiRequestException ex) {
+                _logger.LogWarning(ex, "Failed to clear todo reminder keyboard for todo {TodoId}", todoId);
+            }
+        }
+    }
+}

--- a/TelegramSearchBot/Service/Scheduler/TodoReminderTask.cs
+++ b/TelegramSearchBot/Service/Scheduler/TodoReminderTask.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Telegram.Bot;
+using Telegram.Bot.Types.Enums;
+using Telegram.Bot.Types.ReplyMarkups;
+using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Manager;
+using TelegramSearchBot.Service.Todo;
+
+namespace TelegramSearchBot.Service.Scheduler {
+    [Injectable(Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton)]
+    public class TodoReminderTask : IScheduledTask {
+        private readonly IServiceProvider _serviceProvider;
+        private readonly ITelegramBotClient _botClient;
+        private readonly SendMessage _sendMessage;
+        private readonly ILogger<TodoReminderTask> _logger;
+        private Func<Task> _heartbeatCallback;
+
+        public TodoReminderTask(
+            IServiceProvider serviceProvider,
+            ITelegramBotClient botClient,
+            SendMessage sendMessage,
+            ILogger<TodoReminderTask> logger) {
+            _serviceProvider = serviceProvider;
+            _botClient = botClient;
+            _sendMessage = sendMessage;
+            _logger = logger;
+        }
+
+        public string TaskName => "TodoReminder";
+
+        public string CronExpression => "* * * * *";
+
+        public void SetHeartbeatCallback(Func<Task> heartbeatCallback) {
+            _heartbeatCallback = heartbeatCallback;
+        }
+
+        public async Task ExecuteAsync() {
+            using var scope = _serviceProvider.CreateScope();
+            var todoService = scope.ServiceProvider.GetRequiredService<TodoService>();
+            var dueTodos = await todoService.GetPendingRemindersAsync(DateTime.UtcNow);
+
+            foreach (var todo in dueTodos) {
+                if (_heartbeatCallback != null) {
+                    await _heartbeatCallback();
+                }
+
+                var reminderText = todoService.BuildReminderMessage(todo);
+                var keyboard = new InlineKeyboardMarkup(new[] {
+                    new[] {
+                        InlineKeyboardButton.WithCallbackData("✅ 标记完成", $"todo_complete:{todo.Id}")
+                    }
+                });
+
+                var sentMessage = await _sendMessage.AddTaskWithResult(
+                    async () => await _botClient.SendMessage(
+                        chatId: todo.ChatId,
+                        text: reminderText,
+                        parseMode: ParseMode.Html,
+                        replyMarkup: keyboard),
+                    todo.ChatId);
+
+                await todoService.MarkReminderSentAsync(todo.Id, sentMessage.MessageId, DateTime.UtcNow);
+                _logger.LogInformation("Sent reminder for todo {TodoId} to chat {ChatId}", todo.Id, todo.ChatId);
+            }
+        }
+    }
+}

--- a/TelegramSearchBot/Service/Todo/TodoService.cs
+++ b/TelegramSearchBot/Service/Todo/TodoService.cs
@@ -1,0 +1,427 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Web;
+using Microsoft.EntityFrameworkCore;
+using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Interface;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Model.Data;
+using TelegramSearchBot.Model.Tools;
+
+namespace TelegramSearchBot.Service.Todo {
+    [Injectable(Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient)]
+    public class TodoService : IService {
+        public const string DefaultListName = "默认";
+        private const int MaxPageSize = 50;
+
+        private readonly DataDbContext _dbContext;
+
+        public TodoService(DataDbContext dbContext) {
+            _dbContext = dbContext;
+        }
+
+        public string ServiceName => "TodoService";
+
+        public async Task<TodoItemResult> CreateTodoAsync(
+            long chatId,
+            long userId,
+            long? sourceMessageId,
+            string title,
+            string listName = null,
+            string description = null,
+            string priority = null,
+            string dueAt = null,
+            string remindAt = null) {
+            if (chatId == 0) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = "ChatId is required to create a todo."
+                };
+            }
+
+            if (string.IsNullOrWhiteSpace(title)) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = "Title is required."
+                };
+            }
+
+            title = title.Trim();
+            if (title.Length > 200) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = "Title must be 200 characters or fewer."
+                };
+            }
+
+            var normalizedListName = NormalizeListName(listName);
+            if (normalizedListName.Length > 100) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = "List name must be 100 characters or fewer."
+                };
+            }
+
+            description = ( description ?? string.Empty ).Trim();
+            if (description.Length > 2000) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = "Description must be 2000 characters or fewer."
+                };
+            }
+
+            priority = NormalizePriority(priority);
+            if (priority.Length > 20) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = "Priority must be 20 characters or fewer."
+                };
+            }
+
+            if (!TryParseDateTime(dueAt, out var dueAtUtc, out var dueAtError)) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = dueAtError
+                };
+            }
+
+            if (!TryParseDateTime(remindAt, out var remindAtUtc, out var remindAtError)) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = remindAtError
+                };
+            }
+
+            if (remindAtUtc.HasValue && dueAtUtc.HasValue && remindAtUtc > dueAtUtc) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    Error = "Reminder time cannot be later than the deadline."
+                };
+            }
+
+            var todoList = await GetOrCreateTodoListAsync(chatId, normalizedListName, userId);
+            var now = DateTime.UtcNow;
+            var todo = new TodoItem {
+                ChatId = chatId,
+                TodoListId = todoList.Id,
+                Title = title,
+                Description = description,
+                Priority = priority,
+                Status = TodoItemStatus.Pending,
+                CreatedBy = userId,
+                SourceMessageId = sourceMessageId,
+                CreatedAt = now,
+                UpdatedAt = now,
+                DueAtUtc = dueAtUtc,
+                RemindAtUtc = remindAtUtc
+            };
+
+            _dbContext.TodoItems.Add(todo);
+            await _dbContext.SaveChangesAsync();
+
+            await _dbContext.Entry(todo).Reference(item => item.TodoList).LoadAsync();
+
+            return new TodoItemResult {
+                Success = true,
+                ChatId = chatId,
+                TodoId = todo.Id,
+                Todo = MapTodo(todo),
+                Note = remindAtUtc.HasValue
+                    ? "Todo created and reminder scheduled."
+                    : "Todo created."
+            };
+        }
+
+        public async Task<TodoQueryResult> QueryTodosAsync(
+            long chatId,
+            string listName = null,
+            string statusFilter = "pending",
+            int page = 1,
+            int pageSize = 10) {
+            if (chatId == 0) {
+                return new TodoQueryResult {
+                    ChatId = chatId,
+                    StatusFilter = statusFilter ?? string.Empty,
+                    Note = "ChatId is required to query todos."
+                };
+            }
+
+            if (page <= 0) {
+                page = 1;
+            }
+
+            if (pageSize <= 0) {
+                pageSize = 10;
+            }
+
+            if (pageSize > MaxPageSize) {
+                pageSize = MaxPageSize;
+            }
+
+            var normalizedStatus = NormalizeStatusFilter(statusFilter);
+            if (normalizedStatus == null) {
+                return new TodoQueryResult {
+                    ChatId = chatId,
+                    ListName = NormalizeListNameOrEmpty(listName),
+                    StatusFilter = statusFilter ?? string.Empty,
+                    CurrentPage = page,
+                    PageSize = pageSize,
+                    Note = "Invalid status filter. Use pending, completed, or all."
+                };
+            }
+
+            var normalizedListName = NormalizeListNameOrEmpty(listName);
+            var query = _dbContext.TodoItems
+                .AsNoTracking()
+                .Include(item => item.TodoList)
+                .Where(item => item.ChatId == chatId);
+
+            if (!string.IsNullOrWhiteSpace(normalizedListName)) {
+                query = query.Where(item => item.TodoList.Name == normalizedListName);
+            }
+
+            query = normalizedStatus switch {
+                "pending" => query.Where(item => item.Status == TodoItemStatus.Pending),
+                "completed" => query.Where(item => item.Status == TodoItemStatus.Completed),
+                _ => query
+            };
+
+            var totalCount = await query.CountAsync();
+            var items = await query
+                .OrderBy(item => item.Status == TodoItemStatus.Pending ? 0 : 1)
+                .ThenBy(item => item.DueAtUtc ?? DateTime.MaxValue)
+                .ThenBy(item => item.RemindAtUtc ?? DateTime.MaxValue)
+                .ThenByDescending(item => item.CreatedAt)
+                .Skip(( page - 1 ) * pageSize)
+                .Take(pageSize)
+                .ToListAsync();
+
+            return new TodoQueryResult {
+                ChatId = chatId,
+                ListName = normalizedListName,
+                StatusFilter = normalizedStatus,
+                CurrentPage = page,
+                PageSize = pageSize,
+                TotalCount = totalCount,
+                Items = items.Select(MapTodo).ToList(),
+                Note = totalCount == 0 ? "No todo items matched the current filter." : string.Empty
+            };
+        }
+
+        public async Task<TodoCompletionResult> CompleteTodoAsync(long chatId, long todoId, long completedBy) {
+            if (chatId == 0) {
+                return new TodoCompletionResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = "ChatId is required to complete a todo."
+                };
+            }
+
+            var todo = await _dbContext.TodoItems
+                .Include(item => item.TodoList)
+                .FirstOrDefaultAsync(item => item.ChatId == chatId && item.Id == todoId);
+
+            if (todo == null) {
+                return new TodoCompletionResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = "Todo not found in the current chat."
+                };
+            }
+
+            if (todo.Status == TodoItemStatus.Completed) {
+                return new TodoCompletionResult {
+                    Success = true,
+                    ChatId = chatId,
+                    TodoId = todo.Id,
+                    Status = todo.Status,
+                    CompletedAtUtc = todo.CompletedAtUtc,
+                    Todo = MapTodo(todo),
+                    Note = "Todo was already completed."
+                };
+            }
+
+            var now = DateTime.UtcNow;
+            todo.Status = TodoItemStatus.Completed;
+            todo.CompletedAtUtc = now;
+            todo.CompletedBy = completedBy;
+            todo.UpdatedAt = now;
+
+            await _dbContext.SaveChangesAsync();
+
+            return new TodoCompletionResult {
+                Success = true,
+                ChatId = chatId,
+                TodoId = todo.Id,
+                Status = todo.Status,
+                CompletedAtUtc = todo.CompletedAtUtc,
+                Todo = MapTodo(todo),
+                Note = "Todo completed."
+            };
+        }
+
+        public async Task<List<TodoItem>> GetPendingRemindersAsync(DateTime utcNow, int maxCount = 50) {
+            return await _dbContext.TodoItems
+                .Include(item => item.TodoList)
+                .Where(item =>
+                    item.Status == TodoItemStatus.Pending &&
+                    item.RemindAtUtc.HasValue &&
+                    item.ReminderSentAtUtc == null &&
+                    item.RemindAtUtc <= utcNow)
+                .OrderBy(item => item.RemindAtUtc)
+                .ThenBy(item => item.Id)
+                .Take(maxCount)
+                .ToListAsync();
+        }
+
+        public async Task MarkReminderSentAsync(long todoId, long reminderMessageId, DateTime sentAtUtc) {
+            var todo = await _dbContext.TodoItems.FirstOrDefaultAsync(item => item.Id == todoId);
+            if (todo == null) {
+                throw new InvalidOperationException($"Todo {todoId} was not found while marking reminder as sent.");
+            }
+
+            todo.ReminderSentAtUtc = sentAtUtc;
+            todo.ReminderMessageId = reminderMessageId;
+            todo.UpdatedAt = sentAtUtc;
+
+            await _dbContext.SaveChangesAsync();
+        }
+
+        public string BuildReminderMessage(TodoItem todo) {
+            ArgumentNullException.ThrowIfNull(todo);
+            ArgumentNullException.ThrowIfNull(todo.TodoList);
+
+            var lines = new List<string> {
+                "📋 <b>待办提醒</b>",
+                $"🆔 <b>ID:</b> <code>{todo.Id}</code>",
+                $"📚 <b>列表:</b> {Encode(todo.TodoList.Name)}",
+                $"📌 <b>标题:</b> {Encode(todo.Title)}"
+            };
+
+            if (!string.IsNullOrWhiteSpace(todo.Description)) {
+                lines.Add($"📝 <b>描述:</b> {Encode(todo.Description)}");
+            }
+
+            if (!string.IsNullOrWhiteSpace(todo.Priority)) {
+                lines.Add($"🔥 <b>优先级:</b> {Encode(todo.Priority)}");
+            }
+
+            if (todo.RemindAtUtc.HasValue) {
+                lines.Add($"⏰ <b>提醒时间:</b> {FormatUtcForDisplay(todo.RemindAtUtc.Value)}");
+            }
+
+            if (todo.DueAtUtc.HasValue) {
+                lines.Add($"⌛ <b>截止时间:</b> {FormatUtcForDisplay(todo.DueAtUtc.Value)}");
+            }
+
+            lines.Add("📍 <b>状态:</b> 待完成");
+
+            return string.Join(Environment.NewLine, lines);
+        }
+
+        private async Task<TodoList> GetOrCreateTodoListAsync(long chatId, string listName, long userId) {
+            var existing = await _dbContext.TodoLists
+                .FirstOrDefaultAsync(list => list.ChatId == chatId && list.Name == listName);
+
+            if (existing != null) {
+                existing.UpdatedAt = DateTime.UtcNow;
+                await _dbContext.SaveChangesAsync();
+                return existing;
+            }
+
+            var todoList = new TodoList {
+                ChatId = chatId,
+                Name = listName,
+                CreatedBy = userId,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            _dbContext.TodoLists.Add(todoList);
+            await _dbContext.SaveChangesAsync();
+            return todoList;
+        }
+
+        private static TodoToolItem MapTodo(TodoItem todo) {
+            return new TodoToolItem {
+                TodoId = todo.Id,
+                ChatId = todo.ChatId,
+                ListName = todo.TodoList?.Name ?? string.Empty,
+                Title = todo.Title,
+                Description = todo.Description ?? string.Empty,
+                Priority = todo.Priority ?? string.Empty,
+                Status = todo.Status,
+                CreatedAtUtc = todo.CreatedAt,
+                DueAtUtc = todo.DueAtUtc,
+                RemindAtUtc = todo.RemindAtUtc,
+                ReminderSentAtUtc = todo.ReminderSentAtUtc,
+                CompletedAtUtc = todo.CompletedAtUtc,
+                SourceMessageId = todo.SourceMessageId
+            };
+        }
+
+        private static string NormalizeListName(string listName) {
+            return string.IsNullOrWhiteSpace(listName) ? DefaultListName : listName.Trim();
+        }
+
+        private static string NormalizeListNameOrEmpty(string listName) {
+            return string.IsNullOrWhiteSpace(listName) ? string.Empty : listName.Trim();
+        }
+
+        private static string NormalizePriority(string priority) {
+            return string.IsNullOrWhiteSpace(priority) ? string.Empty : priority.Trim();
+        }
+
+        private static string? NormalizeStatusFilter(string statusFilter) {
+            if (string.IsNullOrWhiteSpace(statusFilter)) {
+                return "pending";
+            }
+
+            var normalized = statusFilter.Trim().ToLowerInvariant();
+            return normalized is "pending" or "completed" or "all" ? normalized : null;
+        }
+
+        private static bool TryParseDateTime(string input, out DateTime? utcDateTime, out string error) {
+            utcDateTime = null;
+            error = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(input)) {
+                return true;
+            }
+
+            if (!DateTimeOffset.TryParse(
+                    input,
+                    CultureInfo.InvariantCulture,
+                    DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AssumeLocal,
+                    out var parsed)) {
+                error = $"Invalid date/time format: '{input}'. Use a parseable timestamp such as 2026-04-22T18:30:00+08:00.";
+                return false;
+            }
+
+            utcDateTime = parsed.UtcDateTime;
+            return true;
+        }
+
+        private static string FormatUtcForDisplay(DateTime utcDateTime) {
+            return utcDateTime.ToLocalTime().ToString("yyyy-MM-dd HH:mm");
+        }
+
+        private static string Encode(string value) {
+            return HttpUtility.HtmlEncode(value ?? string.Empty);
+        }
+    }
+}

--- a/TelegramSearchBot/Service/Todo/TodoService.cs
+++ b/TelegramSearchBot/Service/Todo/TodoService.cs
@@ -220,6 +220,202 @@ namespace TelegramSearchBot.Service.Todo {
             };
         }
 
+        public async Task<TodoItemResult> UpdateTodoAsync(
+            long chatId,
+            long todoId,
+            long updatedBy,
+            string title = null,
+            string listName = null,
+            string description = null,
+            string priority = null,
+            string dueAt = null,
+            string remindAt = null) {
+            if (chatId == 0) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = "ChatId is required to update a todo."
+                };
+            }
+
+            if (todoId <= 0) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = "todoId must be greater than zero."
+                };
+            }
+
+            var todo = await _dbContext.TodoItems
+                .Include(item => item.TodoList)
+                .FirstOrDefaultAsync(item => item.ChatId == chatId && item.Id == todoId);
+
+            if (todo == null) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = "Todo not found in the current chat."
+                };
+            }
+
+            if (todo.Status == TodoItemStatus.Completed) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = "Completed todos cannot be edited."
+                };
+            }
+
+            var changed = false;
+            var reminderChanged = false;
+
+            if (title != null) {
+                if (string.IsNullOrWhiteSpace(title)) {
+                    return new TodoItemResult {
+                        Success = false,
+                        ChatId = chatId,
+                        TodoId = todoId,
+                        Error = "Title cannot be empty when updating a todo."
+                    };
+                }
+
+                var normalizedTitle = title.Trim();
+                if (normalizedTitle.Length > 200) {
+                    return new TodoItemResult {
+                        Success = false,
+                        ChatId = chatId,
+                        TodoId = todoId,
+                        Error = "Title must be 200 characters or fewer."
+                    };
+                }
+
+                if (!string.Equals(todo.Title, normalizedTitle, StringComparison.Ordinal)) {
+                    todo.Title = normalizedTitle;
+                    changed = true;
+                }
+            }
+
+            if (listName != null) {
+                var normalizedListName = NormalizeListName(listName);
+                if (normalizedListName.Length > 100) {
+                    return new TodoItemResult {
+                        Success = false,
+                        ChatId = chatId,
+                        TodoId = todoId,
+                        Error = "List name must be 100 characters or fewer."
+                    };
+                }
+
+                if (!string.Equals(todo.TodoList.Name, normalizedListName, StringComparison.Ordinal)) {
+                    var todoList = await GetOrCreateTodoListAsync(chatId, normalizedListName, updatedBy);
+                    todo.TodoListId = todoList.Id;
+                    todo.TodoList = todoList;
+                    changed = true;
+                }
+            }
+
+            if (description != null) {
+                var normalizedDescription = description.Trim();
+                if (normalizedDescription.Length > 2000) {
+                    return new TodoItemResult {
+                        Success = false,
+                        ChatId = chatId,
+                        TodoId = todoId,
+                        Error = "Description must be 2000 characters or fewer."
+                    };
+                }
+
+                if (!string.Equals(todo.Description ?? string.Empty, normalizedDescription, StringComparison.Ordinal)) {
+                    todo.Description = normalizedDescription;
+                    changed = true;
+                }
+            }
+
+            if (priority != null) {
+                var normalizedPriority = NormalizePriority(priority);
+                if (normalizedPriority.Length > 20) {
+                    return new TodoItemResult {
+                        Success = false,
+                        ChatId = chatId,
+                        TodoId = todoId,
+                        Error = "Priority must be 20 characters or fewer."
+                    };
+                }
+
+                if (!string.Equals(todo.Priority ?? string.Empty, normalizedPriority, StringComparison.Ordinal)) {
+                    todo.Priority = normalizedPriority;
+                    changed = true;
+                }
+            }
+
+            if (!TryResolveDateTimeUpdate(dueAt, todo.DueAtUtc, out var dueChanged, out var resolvedDueAtUtc, out var dueAtError)) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = dueAtError
+                };
+            }
+
+            if (!TryResolveDateTimeUpdate(remindAt, todo.RemindAtUtc, out var remindChanged, out var resolvedRemindAtUtc, out var remindAtError)) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = remindAtError
+                };
+            }
+
+            if (resolvedRemindAtUtc.HasValue && resolvedDueAtUtc.HasValue && resolvedRemindAtUtc > resolvedDueAtUtc) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = chatId,
+                    TodoId = todoId,
+                    Error = "Reminder time cannot be later than the deadline."
+                };
+            }
+
+            if (dueChanged) {
+                todo.DueAtUtc = resolvedDueAtUtc;
+                changed = true;
+            }
+
+            if (remindChanged) {
+                todo.RemindAtUtc = resolvedRemindAtUtc;
+                todo.ReminderSentAtUtc = null;
+                todo.ReminderMessageId = null;
+                changed = true;
+                reminderChanged = true;
+            }
+
+            if (!changed) {
+                return new TodoItemResult {
+                    Success = true,
+                    ChatId = chatId,
+                    TodoId = todo.Id,
+                    Todo = MapTodo(todo),
+                    Note = "No todo fields changed."
+                };
+            }
+
+            todo.UpdatedAt = DateTime.UtcNow;
+            await _dbContext.SaveChangesAsync();
+
+            return new TodoItemResult {
+                Success = true,
+                ChatId = chatId,
+                TodoId = todo.Id,
+                Todo = MapTodo(todo),
+                Note = reminderChanged
+                    ? "Todo updated and reminder schedule refreshed."
+                    : "Todo updated."
+            };
+        }
+
         public async Task<TodoCompletionResult> CompleteTodoAsync(long chatId, long todoId, long completedBy) {
             if (chatId == 0) {
                 return new TodoCompletionResult {
@@ -413,6 +609,39 @@ namespace TelegramSearchBot.Service.Todo {
             }
 
             utcDateTime = parsed.UtcDateTime;
+            return true;
+        }
+
+        private static bool TryResolveDateTimeUpdate(
+            string input,
+            DateTime? currentValue,
+            out bool changed,
+            out DateTime? resolvedValue,
+            out string error) {
+            changed = false;
+            resolvedValue = currentValue;
+            error = string.Empty;
+
+            if (input == null) {
+                return true;
+            }
+
+            var normalizedInput = input.Trim();
+            if (normalizedInput.Length == 0 ||
+                normalizedInput.Equals("clear", StringComparison.OrdinalIgnoreCase) ||
+                normalizedInput.Equals("none", StringComparison.OrdinalIgnoreCase) ||
+                normalizedInput.Equals("null", StringComparison.OrdinalIgnoreCase)) {
+                changed = currentValue.HasValue;
+                resolvedValue = null;
+                return true;
+            }
+
+            if (!TryParseDateTime(normalizedInput, out var parsedValue, out error)) {
+                return false;
+            }
+
+            changed = currentValue != parsedValue;
+            resolvedValue = parsedValue;
             return true;
         }
 

--- a/TelegramSearchBot/Service/Tools/TodoToolService.cs
+++ b/TelegramSearchBot/Service/Tools/TodoToolService.cs
@@ -1,0 +1,121 @@
+using System.Threading.Tasks;
+using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Interface;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Model.Tools;
+using TelegramSearchBot.Service.Todo;
+
+namespace TelegramSearchBot.Service.Tools {
+    [Injectable(Microsoft.Extensions.DependencyInjection.ServiceLifetime.Transient)]
+    public class TodoToolService : IService {
+        private readonly TodoService _todoService;
+
+        public TodoToolService(TodoService todoService) {
+            _todoService = todoService;
+        }
+
+        public string ServiceName => "TodoToolService";
+
+        [BuiltInTool("Creates a persistent todo item in the current chat. Supports multiple todo lists, optional deadline, and optional reminder time. Prefer explicit ISO 8601 timestamps with timezone offsets.", Name = "create_todo_item")]
+        public Task<TodoItemResult> CreateTodoItem(
+            [BuiltInParameter("Short todo title. Keep it concise and specific.", IsRequired = true)] string title,
+            ToolContext toolContext,
+            [BuiltInParameter("Optional todo list name. If omitted, the default list is used.", IsRequired = false)] string listName = null,
+            [BuiltInParameter("Optional detailed description or acceptance criteria.", IsRequired = false)] string description = null,
+            [BuiltInParameter("Optional priority label such as low, medium, high, or urgent.", IsRequired = false)] string priority = null,
+            [BuiltInParameter("Optional due timestamp. Prefer ISO 8601 with timezone, e.g. 2026-04-22T18:30:00+08:00.", IsRequired = false)] string dueAt = null,
+            [BuiltInParameter("Optional reminder timestamp. Prefer ISO 8601 with timezone. The bot will remind the chat at this time.", IsRequired = false)] string remindAt = null) {
+            var validationError = ValidateToolContext(toolContext);
+            if (validationError != null) {
+                return Task.FromResult(validationError);
+            }
+
+            return _todoService.CreateTodoAsync(
+                toolContext.ChatId,
+                toolContext.UserId,
+                toolContext.MessageId == 0 ? null : toolContext.MessageId,
+                title,
+                listName,
+                description,
+                priority,
+                dueAt,
+                remindAt);
+        }
+
+        [BuiltInTool("Queries todo items in the current chat. Use this before completing a todo if you need to discover its todoId. By default, only pending items are returned.", Name = "query_todo_items")]
+        public Task<TodoQueryResult> QueryTodoItems(
+            ToolContext toolContext,
+            [BuiltInParameter("Optional todo list name to filter by.", IsRequired = false)] string listName = null,
+            [BuiltInParameter("Status filter: pending, completed, or all. Defaults to pending.", IsRequired = false)] string status = "pending",
+            [BuiltInParameter("Page number for pagination. Defaults to 1.", IsRequired = false)] int page = 1,
+            [BuiltInParameter("Number of results per page. Defaults to 10 and is capped at 50.", IsRequired = false)] int pageSize = 10) {
+            var validationError = ValidateQueryToolContext(toolContext, listName, status, page, pageSize);
+            if (validationError != null) {
+                return Task.FromResult(validationError);
+            }
+
+            return _todoService.QueryTodosAsync(toolContext.ChatId, listName, status, page, pageSize);
+        }
+
+        [BuiltInTool("Marks a todo item as completed in the current chat. If the todoId is unknown, query todos first.", Name = "complete_todo_item")]
+        public Task<TodoCompletionResult> CompleteTodoItem(
+            [BuiltInParameter("The numeric todoId to complete.", IsRequired = true)] long todoId,
+            ToolContext toolContext) {
+            var validationError = ValidateCompletionToolContext(toolContext, todoId);
+            if (validationError != null) {
+                return Task.FromResult(validationError);
+            }
+
+            return _todoService.CompleteTodoAsync(toolContext.ChatId, todoId, toolContext.UserId);
+        }
+
+        private static TodoItemResult ValidateToolContext(ToolContext toolContext) {
+            if (toolContext == null || toolContext.ChatId == 0) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = toolContext?.ChatId ?? 0,
+                    Error = "ToolContext.ChatId is required."
+                };
+            }
+
+            return null;
+        }
+
+        private static TodoQueryResult ValidateQueryToolContext(ToolContext toolContext, string listName, string status, int page, int pageSize) {
+            if (toolContext == null || toolContext.ChatId == 0) {
+                return new TodoQueryResult {
+                    ChatId = toolContext?.ChatId ?? 0,
+                    ListName = listName ?? string.Empty,
+                    StatusFilter = status ?? string.Empty,
+                    CurrentPage = page,
+                    PageSize = pageSize,
+                    Note = "ToolContext.ChatId is required."
+                };
+            }
+
+            return null;
+        }
+
+        private static TodoCompletionResult ValidateCompletionToolContext(ToolContext toolContext, long todoId) {
+            if (toolContext == null || toolContext.ChatId == 0) {
+                return new TodoCompletionResult {
+                    Success = false,
+                    ChatId = toolContext?.ChatId ?? 0,
+                    TodoId = todoId,
+                    Error = "ToolContext.ChatId is required."
+                };
+            }
+
+            if (todoId <= 0) {
+                return new TodoCompletionResult {
+                    Success = false,
+                    ChatId = toolContext.ChatId,
+                    TodoId = todoId,
+                    Error = "todoId must be greater than zero."
+                };
+            }
+
+            return null;
+        }
+    }
+}

--- a/TelegramSearchBot/Service/Tools/TodoToolService.cs
+++ b/TelegramSearchBot/Service/Tools/TodoToolService.cs
@@ -57,6 +57,33 @@ namespace TelegramSearchBot.Service.Tools {
             return _todoService.QueryTodosAsync(toolContext.ChatId, listName, status, page, pageSize);
         }
 
+        [BuiltInTool("Updates an existing pending todo item in the current chat. Only provided fields are changed. Pass an empty string, clear, none, or null to clear description, priority, dueAt, or remindAt. Changing remindAt automatically reschedules reminder delivery.", Name = "update_todo_item")]
+        public Task<TodoItemResult> UpdateTodoItem(
+            [BuiltInParameter("The numeric todoId to update.", IsRequired = true)] long todoId,
+            ToolContext toolContext,
+            [BuiltInParameter("Optional replacement title. Omit to keep the current title.", IsRequired = false)] string title = null,
+            [BuiltInParameter("Optional replacement todo list name. Omit to keep the current list.", IsRequired = false)] string listName = null,
+            [BuiltInParameter("Optional replacement description. Pass empty string to clear it.", IsRequired = false)] string description = null,
+            [BuiltInParameter("Optional replacement priority. Pass empty string to clear it.", IsRequired = false)] string priority = null,
+            [BuiltInParameter("Optional replacement due timestamp. Pass empty string to clear it. Prefer ISO 8601 with timezone.", IsRequired = false)] string dueAt = null,
+            [BuiltInParameter("Optional replacement reminder timestamp. Pass empty string to clear it. Prefer ISO 8601 with timezone.", IsRequired = false)] string remindAt = null) {
+            var validationError = ValidateUpdateToolContext(toolContext, todoId);
+            if (validationError != null) {
+                return Task.FromResult(validationError);
+            }
+
+            return _todoService.UpdateTodoAsync(
+                toolContext.ChatId,
+                todoId,
+                toolContext.UserId,
+                title,
+                listName,
+                description,
+                priority,
+                dueAt,
+                remindAt);
+        }
+
         [BuiltInTool("Marks a todo item as completed in the current chat. If the todoId is unknown, query todos first.", Name = "complete_todo_item")]
         public Task<TodoCompletionResult> CompleteTodoItem(
             [BuiltInParameter("The numeric todoId to complete.", IsRequired = true)] long todoId,
@@ -90,6 +117,28 @@ namespace TelegramSearchBot.Service.Tools {
                     CurrentPage = page,
                     PageSize = pageSize,
                     Note = "ToolContext.ChatId is required."
+                };
+            }
+
+            return null;
+        }
+
+        private static TodoItemResult ValidateUpdateToolContext(ToolContext toolContext, long todoId) {
+            if (toolContext == null || toolContext.ChatId == 0) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = toolContext?.ChatId ?? 0,
+                    TodoId = todoId,
+                    Error = "ToolContext.ChatId is required."
+                };
+            }
+
+            if (todoId <= 0) {
+                return new TodoItemResult {
+                    Success = false,
+                    ChatId = toolContext.ChatId,
+                    TodoId = todoId,
+                    Error = "todoId must be greater than zero."
                 };
             }
 


### PR DESCRIPTION
## Summary
- supersedes #244 because repository rules block force-pushing the protected `issue-139-todo-tool` branch
- add persistent multi-list todo storage with deadline, reminder, and completion state
- add todo query/complete tools, reminder scheduling, reminder callback handling, and focused tests

## Validation
- dotnet build TelegramSearchBot.sln -c Release
- dotnet test TelegramSearchBot.Test\\TelegramSearchBot.Test.csproj -c Release --filter "FullyQualifiedName~Todo"
- dotnet test TelegramSearchBot.sln -c Release --no-build