### PR TITLE
chore: batch dependency updates and fix PR report

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -62,6 +62,11 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: always() && github.event_name == 'pull_request'
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
     
     steps:
     - name: Generate PR report
@@ -176,9 +181,13 @@ jobs:
           ];
 
           fs.writeFileSync('pr-report.md', `${reportLines.join('\n')}\n`, 'utf8');
+
+    - name: Publish report summary
+      if: always()
+      run: cat pr-report.md >> "$GITHUB_STEP_SUMMARY"
     
     - name: Find existing comment
-      if: always()
+      if: always() && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/github-script@v7
       id: find-comment
       with:
@@ -197,7 +206,7 @@ jobs:
           return botComment?.id;
     
     - name: Create or update comment
-      if: always()
+      if: always() && github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
       uses: actions/github-script@v7
       with:
         script: |

--- a/TelegramSearchBot.Common/TelegramSearchBot.Common.csproj
+++ b/TelegramSearchBot.Common/TelegramSearchBot.Common.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 </Project>

--- a/TelegramSearchBot.Database/TelegramSearchBot.Database.csproj
+++ b/TelegramSearchBot.Database/TelegramSearchBot.Database.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/TelegramSearchBot.LLM.Test/TelegramSearchBot.LLM.Test.csproj
+++ b/TelegramSearchBot.LLM.Test/TelegramSearchBot.LLM.Test.csproj
@@ -8,14 +8,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/TelegramSearchBot.LLM/TelegramSearchBot.LLM.csproj
+++ b/TelegramSearchBot.LLM/TelegramSearchBot.LLM.csproj
@@ -7,13 +7,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Anthropic" Version="12.13.0" />
-    <PackageReference Include="Google_GenerativeAI" Version="3.6.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Anthropic" Version="12.16.0" />
+    <PackageReference Include="Google_GenerativeAI" Version="3.6.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="OllamaSharp" Version="5.4.18" />
     <PackageReference Include="OpenAI" Version="2.9.0" />

--- a/TelegramSearchBot.LLMAgent/TelegramSearchBot.LLMAgent.csproj
+++ b/TelegramSearchBot.LLMAgent/TelegramSearchBot.LLMAgent.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/TelegramSearchBot.Search.Test/TelegramSearchBot.Search.Test.csproj
+++ b/TelegramSearchBot.Search.Test/TelegramSearchBot.Search.Test.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/TelegramSearchBot.Search/TelegramSearchBot.Search.csproj
+++ b/TelegramSearchBot.Search/TelegramSearchBot.Search.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00017" />
-    <PackageReference Include="Lucene.Net.Analysis.SmartCn" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.Analysis.SmartCn" Version="4.8.0-beta00017" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TelegramSearchBot.SubAgent/TelegramSearchBot.SubAgent.csproj
+++ b/TelegramSearchBot.SubAgent/TelegramSearchBot.SubAgent.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.6" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />

--- a/TelegramSearchBot.Test/TelegramSearchBot.Test.csproj
+++ b/TelegramSearchBot.Test/TelegramSearchBot.Test.csproj
@@ -7,12 +7,12 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TelegramSearchBot.Tokenizer.Tests/TelegramSearchBot.Tokenizer.Tests.csproj
+++ b/TelegramSearchBot.Tokenizer.Tests/TelegramSearchBot.Tokenizer.Tests.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/TelegramSearchBot.Tokenizer/TelegramSearchBot.Tokenizer.csproj
+++ b/TelegramSearchBot.Tokenizer/TelegramSearchBot.Tokenizer.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00017" />
-    <PackageReference Include="Lucene.Net.Analysis.SmartCn" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.Analysis.SmartCn" Version="4.8.0-beta00017" />
   </ItemGroup>
 
 </Project>

--- a/TelegramSearchBot/TelegramSearchBot.csproj
+++ b/TelegramSearchBot/TelegramSearchBot.csproj
@@ -19,25 +19,25 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Coravel" Version="6.0.2" />
-    <PackageReference Include="Cronos" Version="0.11.1" />
-    <PackageReference Include="Google_GenerativeAI" Version="3.6.3" />
+    <PackageReference Include="Cronos" Version="0.12.0" />
+    <PackageReference Include="Google_GenerativeAI" Version="3.6.6" />
     <PackageReference Include="HtmlAgilityPack" Version="1.12.4" />
     <PackageReference Include="jieba.NET" Version="0.42.2" />
     <PackageReference Include="LiteDB" Version="5.0.21" />
     <PackageReference Include="FFMpegCore" Version="5.4.0" />
     <PackageReference Include="Lucene.Net" Version="4.8.0-beta00017" />
-    <PackageReference Include="Lucene.Net.Analysis.SmartCn" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.Analysis.SmartCn" Version="4.8.0-beta00017" />
     <PackageReference Include="Magick.NET-Q16-HDRI-AnyCPU" Version="14.12.0" />
-    <PackageReference Include="Markdig" Version="1.1.2" />
-    <PackageReference Include="MediatR" Version="14.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.3">
+    <PackageReference Include="Markdig" Version="1.1.3" />
+    <PackageReference Include="MediatR" Version="14.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.7" />
     <PackageReference Include="Microsoft.Garnet" Version="1.0.99" />
     <PackageReference Include="NCrontab" Version="3.4.0" />
     <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
@@ -78,14 +78,14 @@
     <PackageReference Include="Sdcb.PaddleOCR" Version="3.0.1" />
     <PackageReference Include="Sdcb.PaddleOCR.Models.Local" Version="3.0.1" />
     <PackageReference Include="Sdcb.PaddleInference.runtime.win64.mkl" Version="3.1.0.54" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageReference Include="FaissNet" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ScottPlot" Version="5.1.57" />


### PR DESCRIPTION
## Summary
- batch the open Dependabot dependency bumps into one replacement branch
- align the Microsoft.Extensions and EntityFrameworkCore package versions to remove NU1605 downgrade failures
- keep the PR report job green on Dependabot and fork-style read-only tokens by publishing the report summary and skipping comment writes when the token cannot comment

## Replaces
- #282
- #283
- #284
- #285
- #286
- #287
- #288
- #289
- #290
- #291

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated NuGet package dependencies across the project, including Entity Framework Core, Microsoft.Extensions packages, and third-party libraries
  * Enhanced GitHub Actions workflows with improved permissions management and automated reporting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->