### PR TITLE
feat: migrate app updates to Moder.Update

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,6 +12,10 @@ jobs:
 
   BuildClickOnce:
     runs-on: windows-latest
+    env:
+      LEGACY_BRIDGE_VERSION: '2026.04.23.1'
+      LEGACY_BRIDGE_MARKER: 'legacy-clickonce-bridge-version.txt'
+      MODER_UPDATE_COMMIT: 'd547c9905d0cb706aa163e418ab5ef424a14dc9c'
 
     steps:
     - uses: actions/checkout@v4
@@ -22,6 +26,8 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 10.0.x
+    - name: Setup Rust
+      uses: dtolnay/rust-toolchain@stable
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
     - name: Clear NuGet cache
@@ -108,37 +114,99 @@ jobs:
           dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - name: Publish ClickOnce
+    - name: Compute release versions
+      id: versioning
       shell: pwsh
       env:
         BUILD_NUMBER: ${{github.run_number}}
       run: |
-          $content = 'TelegramSearchBot/Properties/PublishProfiles/ClickOnceProfile.pubxml'
-          $xmldata = [xml](Get-Content $content)
-          $Version = Get-Date -Format "yyyy.MM.dd.$env:BUILD_NUMBER"
-          $env:BUILD_VERSION = Get-Date -Format "yyyy.MM.dd.$env:BUILD_NUMBER"
-          $node = $xmldata.Project.PropertyGroup
-          $node.ApplicationVersion = $Version
-          $node.MinimumRequiredVersion = $Version
-          $xmldata.Save($content)
-          echo $env:BUILD_VERSION
-          msbuild TelegramSearchBot /restore /t:DoPublish /p:Configuration=Release /p:PublishProfile=ClickOnceProfile /p:RuntimeIdentifier=win-x64 /p:SelfContained=true
-          $tfm = ([xml](Get-Content "TelegramSearchBot/TelegramSearchBot.csproj")).Project.PropertyGroup.TargetFramework | Where-Object { $_ } | Select-Object -First 1
-          Copy-Item "TelegramSearchBot/bin/Release/$tfm/win-x64/app.publish/Publish.html" "TelegramSearchBot/bin/TelegramSearchBot/"
-    - name: Upload to ClickOnce Server
+          $buildVersion = Get-Date -Format "yyyy.MM.dd.$env:BUILD_NUMBER"
+          "BUILD_VERSION=$buildVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          "build-version=$buildVersion" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+    - name: Build Moder.Update updater
+      shell: pwsh
+      run: |
+          if (Test-Path moder-update) {
+            Remove-Item moder-update -Recurse -Force
+          }
+          git clone https://github.com/ModerRAS/Moder.Update.git moder-update
+          git -C moder-update checkout $env:MODER_UPDATE_COMMIT
+          cargo build --manifest-path moder-update/src/updater/Cargo.toml --release
+    - name: Publish standalone app
+      shell: pwsh
+      run: |
+          if (Test-Path artifacts) {
+            Remove-Item artifacts -Recurse -Force
+          }
+          dotnet publish .\TelegramSearchBot\TelegramSearchBot.csproj `
+            -c Release `
+            -r win-x64 `
+            --self-contained true `
+            --no-restore `
+            /p:Version=$env:BUILD_VERSION `
+            /p:PublishSingleFile=false `
+            -o .\artifacts\standalone
+    - name: Build Moder.Update feed
+      shell: pwsh
+      run: |
+          dotnet run --project .\TelegramSearchBot.UpdateBuilder\TelegramSearchBot.UpdateBuilder.csproj `
+            -c Release `
+            --no-build `
+            -- `
+            --source-dir .\artifacts\standalone `
+            --output-dir .\artifacts\update-feed `
+            --target-version $env:BUILD_VERSION `
+            --min-source-version $env:LEGACY_BRIDGE_VERSION
+          Copy-Item .\moder-update\src\updater\target\release\moder_update_updater.exe .\artifacts\update-feed\moder_update_updater.exe -Force
+    - name: Check legacy bridge presence
+      id: bridge-check
       shell: pwsh
       env:
-        SOURCE_DIR: 'TelegramSearchBot/bin/TelegramSearchBot'
         B2_BUCKET: ${{ secrets.B2_BUCKET }}
         B2_APPKEY_ID: ${{ secrets.B2_APPKEY_ID }}
         B2_APPKEY: ${{ secrets.B2_APPKEY }}
       run: |
         pip install --quiet --cache-dir C:\pip-cache b2
         b2 account authorize $env:B2_APPKEY_ID $env:B2_APPKEY --quiet
-        b2 sync --delete $env:SOURCE_DIR b2://$env:B2_BUCKET/TelegramSearchBot --quiet
-
-        # TO-DO: Delete old versions of updated files because that's what
-        # we're already using GitHub for... but B2 doesn't make this easy:
-        # https://github.com/Backblaze/B2_Command_Line_Tool/issues/324
-
+        $markerPath = "TelegramSearchBot/$env:LEGACY_BRIDGE_MARKER"
+        $existingMarker = b2 ls --recursive $env:B2_BUCKET $markerPath
+        if ([string]::IsNullOrWhiteSpace($existingMarker)) {
+          "publish-bridge=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        } else {
+          "publish-bridge=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+        }
+        b2 clear-account
+    - name: Publish legacy ClickOnce bridge
+      if: steps.bridge-check.outputs.publish-bridge == 'true'
+      shell: pwsh
+      run: |
+          $content = 'TelegramSearchBot/Properties/PublishProfiles/ClickOnceProfile.pubxml'
+          $xmldata = [xml](Get-Content $content)
+          $node = $xmldata.Project.PropertyGroup
+          $node.ApplicationVersion = $env:LEGACY_BRIDGE_VERSION
+          $node.MinimumRequiredVersion = $env:LEGACY_BRIDGE_VERSION
+          $xmldata.Save($content)
+          msbuild TelegramSearchBot /restore /t:DoPublish /p:Configuration=Release /p:PublishProfile=ClickOnceProfile /p:RuntimeIdentifier=win-x64 /p:SelfContained=true /p:Version=$env:LEGACY_BRIDGE_VERSION
+          $bridgeDir = '.\artifacts\legacy-bridge'
+          if (Test-Path $bridgeDir) {
+            Remove-Item $bridgeDir -Recurse -Force
+          }
+          New-Item -ItemType Directory -Path $bridgeDir | Out-Null
+          Copy-Item .\TelegramSearchBot\bin\TelegramSearchBot\* $bridgeDir -Recurse -Force
+          Set-Content -Path (Join-Path $bridgeDir $env:LEGACY_BRIDGE_MARKER) -Value $env:LEGACY_BRIDGE_VERSION -Encoding utf8
+    - name: Upload release artifacts
+      shell: pwsh
+      env:
+        B2_BUCKET: ${{ secrets.B2_BUCKET }}
+        B2_APPKEY_ID: ${{ secrets.B2_APPKEY_ID }}
+        B2_APPKEY: ${{ secrets.B2_APPKEY }}
+      run: |
+        pip install --quiet --cache-dir C:\pip-cache b2
+        b2 account authorize $env:B2_APPKEY_ID $env:B2_APPKEY --quiet
+        if ("${{ steps.bridge-check.outputs.publish-bridge }}" -eq "true") {
+          b2 sync .\artifacts\legacy-bridge b2://$env:B2_BUCKET/TelegramSearchBot --quiet
+        }
+        b2 sync .\artifacts\update-feed\packages b2://$env:B2_BUCKET/TelegramSearchBot/packages --quiet
+        b2 upload-file $env:B2_BUCKET .\artifacts\update-feed\catalog.json TelegramSearchBot/catalog.json
+        b2 upload-file $env:B2_BUCKET .\artifacts\update-feed\moder_update_updater.exe TelegramSearchBot/moder_update_updater.exe
         b2 clear-account

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -111,9 +111,9 @@ jobs:
       run: dotnet restore --force --no-cache /p:BuildWithNetFrameworkHostedCompiler=true
     - name: Build
       run: |
-          dotnet build --no-restore
+          dotnet build --no-restore -c Release
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build -c Release --verbosity normal
     - name: Compute release versions
       id: versioning
       shell: pwsh
@@ -158,6 +158,10 @@ jobs:
             --target-version $env:BUILD_VERSION `
             --min-source-version $env:LEGACY_BRIDGE_VERSION
           Copy-Item .\moder-update\src\updater\target\release\moder_update_updater.exe .\artifacts\update-feed\moder_update_updater.exe -Force
+          $catalogPath = '.\artifacts\update-feed\catalog.json'
+          $catalog = Get-Content $catalogPath -Raw | ConvertFrom-Json
+          $catalog | Add-Member -NotePropertyName UpdaterChecksum -NotePropertyValue ((Get-FileHash .\artifacts\update-feed\moder_update_updater.exe -Algorithm SHA512).Hash.ToLower()) -Force
+          $catalog | ConvertTo-Json -Depth 10 | Set-Content $catalogPath -Encoding utf8
     - name: Check legacy bridge presence
       id: bridge-check
       shell: pwsh
@@ -207,6 +211,6 @@ jobs:
           b2 sync .\artifacts\legacy-bridge b2://$env:B2_BUCKET/TelegramSearchBot --quiet
         }
         b2 sync .\artifacts\update-feed\packages b2://$env:B2_BUCKET/TelegramSearchBot/packages --quiet
-        b2 upload-file $env:B2_BUCKET .\artifacts\update-feed\catalog.json TelegramSearchBot/catalog.json
         b2 upload-file $env:B2_BUCKET .\artifacts\update-feed\moder_update_updater.exe TelegramSearchBot/moder_update_updater.exe
+        b2 upload-file $env:B2_BUCKET .\artifacts\update-feed\catalog.json TelegramSearchBot/catalog.json
         b2 clear-account

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,7 +13,7 @@ jobs:
   BuildClickOnce:
     runs-on: windows-latest
     env:
-      LEGACY_BRIDGE_VERSION: '2026.04.23.1'
+      LEGACY_BRIDGE_VERSION: '2026.04.23.553'
       LEGACY_BRIDGE_MARKER: 'legacy-clickonce-bridge-version.txt'
       MODER_UPDATE_COMMIT: 'd547c9905d0cb706aa163e418ab5ef424a14dc9c'
 

--- a/Docs/Build_and_Test_Guide.md
+++ b/Docs/Build_and_Test_Guide.md
@@ -38,7 +38,7 @@ dotnet run --project TelegramSearchBot.UpdateBuilder/TelegramSearchBot.UpdateBui
   --source-dir ./publish \
   --output-dir ./update-feed \
   --target-version 2026.04.23.2 \
-  --min-source-version 2026.04.23.1
+  --min-source-version 2026.04.23.553
 ```
 
 **Linux 平台**

--- a/Docs/Build_and_Test_Guide.md
+++ b/Docs/Build_and_Test_Guide.md
@@ -32,6 +32,13 @@ dotnet publish TelegramSearchBot/TelegramSearchBot.csproj -c Release -r win-x64 
 
 # 发布 Windows 单文件版本
 dotnet publish TelegramSearchBot/TelegramSearchBot.csproj -c Release -r win-x64 --self-contained -p:PublishSingleFile=true
+
+# 生成 Moder.Update 兼容更新源
+dotnet run --project TelegramSearchBot.UpdateBuilder/TelegramSearchBot.UpdateBuilder.csproj -c Release -- \
+  --source-dir ./publish \
+  --output-dir ./update-feed \
+  --target-version 2026.04.23.2 \
+  --min-source-version 2026.04.23.1
 ```
 
 **Linux 平台**
@@ -226,6 +233,10 @@ jobs:
     - name: Test
       run: dotnet test --no-build --verbosity normal
 ```
+
+仓库内实际的 `push.yml` 现在维护两条发布线：
+- 保留根目录中的最终 ClickOnce bridge，供旧安装版本过渡到新更新链路。
+- 每次主分支发布都会生成 `catalog.json`、`packages/` 和 `moder_update_updater.exe`，供 `%LOCALAPPDATA%\TelegramSearchBot\app` 中的独立安装目录继续使用 Moder.Update 协议升级。
 
 ### 监控与日志
 

--- a/Docs/Build_and_Test_Guide.md
+++ b/Docs/Build_and_Test_Guide.md
@@ -28,10 +28,10 @@ dotnet build TelegramSearchBot/TelegramSearchBot.csproj --configuration Release
 **Windows 平台**
 ```bash
 # 发布 Windows 版本
-dotnet publish TelegramSearchBot/TelegramSearchBot.csproj -c Release -r win-x64 --self-contained
+dotnet publish TelegramSearchBot/TelegramSearchBot.csproj -c Release -r win-x64 --self-contained --output ./publish
 
 # 发布 Windows 单文件版本
-dotnet publish TelegramSearchBot/TelegramSearchBot.csproj -c Release -r win-x64 --self-contained -p:PublishSingleFile=true
+dotnet publish TelegramSearchBot/TelegramSearchBot.csproj -c Release -r win-x64 --self-contained -p:PublishSingleFile=true --output ./publish
 
 # 生成 Moder.Update 兼容更新源
 dotnet run --project TelegramSearchBot.UpdateBuilder/TelegramSearchBot.UpdateBuilder.csproj -c Release -- \
@@ -267,4 +267,4 @@ dotnet counters monitor --process-id <pid>
 - [架构概览](./Architecture_Overview.md)
 - [用户指南](./Bot_Commands_User_Guide.md)
 
-*最后更新: 2025-07-19*
+*最后更新: 2026-04-23*

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 ## 安装与配置
 
 ### 快速开始
-1. 下载[最新版本](https://clickonce.miaostay.com/TelegramSearchBot/Publish.html)
+1. 下载[最新版本](https://clickonce.miaostay.com/TelegramSearchBot/Publish.html)（首次安装仍使用 ClickOnce，后续版本会迁移到 `%LOCALAPPDATA%\TelegramSearchBot\app` 并由内置更新器继续升级）
 2. 首次运行会自动生成配置目录
 3. 编辑`AppData/Local/TelegramSearchBot/Config.json`:
 
@@ -43,6 +43,8 @@
   "AdminId": 123456789,
   "EnableAutoOCR": false,
   "EnableAutoASR": false,
+  "EnableAutoUpdate": true,
+  "UpdateBaseUrl": "https://clickonce.miaostay.com/TelegramSearchBot",
   "IsLocalAPI": false,
   "EnableLocalBotAPI": false,
   "ExternalLocalBotApiBaseUrl": "",
@@ -88,6 +90,11 @@
   - `LocalBotApiPort`: 本地Bot API服务端口(默认8081)
   - **说明**: `EnableLocalBotAPI=true` 时会启动内置 `telegram-bot-api.exe`；若使用外部 local API，请保持 `EnableLocalBotAPI=false` 并填写 `ExternalLocalBotApiBaseUrl`
   - **优势**: 使用本地 Bot API（内置或外部）后可发送最大2GB文件（vs 云端50MB限制）
+
+- **自动更新**:
+  - `EnableAutoUpdate`: 是否启用内置自更新流程(默认true)
+  - `UpdateBaseUrl`: 更新目录根地址，默认使用 `https://clickonce.miaostay.com/TelegramSearchBot`
+  - **说明**: 首次安装仍通过 `Publish.html` 分发桥接版；之后程序会从 `catalog.json`、`packages/` 和 `moder_update_updater.exe` 拉取更新并升级独立安装目录
 
 - **AI相关**:
   - `OllamaModelName`: 本地模型名称(默认"qwen2.5:72b-instruct-q2_K")

--- a/TelegramSearchBot.Common/Env.cs
+++ b/TelegramSearchBot.Common/Env.cs
@@ -139,7 +139,19 @@ namespace TelegramSearchBot.Common {
 
         public static string ResolveUpdateBaseUrl(Config config) {
             ArgumentNullException.ThrowIfNull(config);
-            return NormalizeBaseUrl(config.UpdateBaseUrl, DefaultUpdateBaseUrl);
+            if (string.IsNullOrWhiteSpace(config.UpdateBaseUrl)) {
+                return DefaultUpdateBaseUrl;
+            }
+
+            if (!Uri.TryCreate(config.UpdateBaseUrl.Trim(), UriKind.Absolute, out var uri)) {
+                return DefaultUpdateBaseUrl;
+            }
+
+            if (!uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase) && !uri.IsLoopback) {
+                return DefaultUpdateBaseUrl;
+            }
+
+            return NormalizeBaseUrl(uri.ToString(), DefaultUpdateBaseUrl);
         }
     }
     public class Config {

--- a/TelegramSearchBot.Common/Env.cs
+++ b/TelegramSearchBot.Common/Env.cs
@@ -44,6 +44,8 @@ namespace TelegramSearchBot.Common {
             OLTPName = config.OLTPName;
             BraveApiKey = config.BraveApiKey;
             EnableAccounting = config.EnableAccounting;
+            EnableAutoUpdate = config.EnableAutoUpdate;
+            UpdateBaseUrl = ResolveUpdateBaseUrl(config);
             MaxToolCycles = config.MaxToolCycles;
             EnableLLMAgentProcess = config.EnableLLMAgentProcess;
             AgentHeartbeatIntervalSeconds = config.AgentHeartbeatIntervalSeconds;
@@ -91,6 +93,7 @@ namespace TelegramSearchBot.Common {
         }
 
         public static readonly string BaseUrl = null!;
+        public const string DefaultUpdateBaseUrl = "https://clickonce.miaostay.com/TelegramSearchBot";
 #pragma warning disable CS8604 // 引用类型参数可能为 null。
         public static readonly bool IsLocalAPI;
 #pragma warning restore CS8604 // 引用类型参数可能为 null。
@@ -98,12 +101,14 @@ namespace TelegramSearchBot.Common {
         public static readonly long AdminId;
         public static readonly bool EnableAutoOCR;
         public static readonly bool EnableAutoASR;
+        public static readonly bool EnableAutoUpdate;
         public static readonly bool EnableLocalBotAPI;
         public static readonly string TelegramBotApiId = null!;
         public static readonly string TelegramBotApiHash = null!;
         public static readonly int LocalBotApiPort;
         public static readonly string ExternalLocalBotApiBaseUrl = string.Empty;
         public static readonly string WorkDir = null!;
+        public static readonly string UpdateBaseUrl = null!;
         public static readonly int TaskDelayTimeout;
         public static readonly bool SameServer;
         public static long BotId { get; set; }
@@ -131,6 +136,11 @@ namespace TelegramSearchBot.Common {
         public static int AgentProcessMemoryLimitMb { get; set; } = 256;
 
         public static Dictionary<string, string> Configuration { get; set; } = new Dictionary<string, string>();
+
+        public static string ResolveUpdateBaseUrl(Config config) {
+            ArgumentNullException.ThrowIfNull(config);
+            return NormalizeBaseUrl(config.UpdateBaseUrl, DefaultUpdateBaseUrl);
+        }
     }
     public class Config {
         public string BaseUrl { get; set; } = "https://api.telegram.org";
@@ -138,6 +148,8 @@ namespace TelegramSearchBot.Common {
         public long AdminId { get; set; }
         public bool EnableAutoOCR { get; set; } = false;
         public bool EnableAutoASR { get; set; } = false;
+        public bool EnableAutoUpdate { get; set; } = true;
+        public string UpdateBaseUrl { get; set; } = Env.DefaultUpdateBaseUrl;
         //public string WorkDir { get; set; } = "/data/TelegramSearchBot";
         public bool IsLocalAPI { get; set; } = false;
         public bool EnableLocalBotAPI { get; set; } = false;

--- a/TelegramSearchBot.Test/Common/EnvBotApiEndpointTests.cs
+++ b/TelegramSearchBot.Test/Common/EnvBotApiEndpointTests.cs
@@ -41,5 +41,23 @@ namespace TelegramSearchBot.Test.Common {
             Assert.Equal("https://api.telegram.org", result.BaseUrl);
             Assert.False(result.IsLocalApi);
         }
+
+        [Fact]
+        public void ResolveUpdateBaseUrl_TrimsTrailingSlash() {
+            var result = Env.ResolveUpdateBaseUrl(new Config {
+                UpdateBaseUrl = "https://clickonce.miaostay.com/TelegramSearchBot/"
+            });
+
+            Assert.Equal("https://clickonce.miaostay.com/TelegramSearchBot", result);
+        }
+
+        [Fact]
+        public void ResolveUpdateBaseUrl_FallsBackToDefaultWhenBlank() {
+            var result = Env.ResolveUpdateBaseUrl(new Config {
+                UpdateBaseUrl = "   "
+            });
+
+            Assert.Equal(Env.DefaultUpdateBaseUrl, result);
+        }
     }
 }

--- a/TelegramSearchBot.Test/Common/EnvBotApiEndpointTests.cs
+++ b/TelegramSearchBot.Test/Common/EnvBotApiEndpointTests.cs
@@ -59,5 +59,14 @@ namespace TelegramSearchBot.Test.Common {
 
             Assert.Equal(Env.DefaultUpdateBaseUrl, result);
         }
+
+        [Fact]
+        public void ResolveUpdateBaseUrl_FallsBackToDefaultWhenUrlIsNotHttpsOrLoopback() {
+            var result = Env.ResolveUpdateBaseUrl(new Config {
+                UpdateBaseUrl = "http://example.com/update"
+            });
+
+            Assert.Equal(Env.DefaultUpdateBaseUrl, result);
+        }
     }
 }

--- a/TelegramSearchBot.UpdateBuilder/Program.cs
+++ b/TelegramSearchBot.UpdateBuilder/Program.cs
@@ -1,0 +1,237 @@
+using System.Formats.Tar;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using ZstdSharp;
+
+var arguments = BuilderArguments.Parse(args);
+if (!arguments.IsValid) {
+    BuilderArguments.PrintUsage();
+    return 1;
+}
+
+var sourceDirectory = Path.GetFullPath(arguments.SourceDirectory!);
+var outputDirectory = Path.GetFullPath(arguments.OutputDirectory!);
+if (!Directory.Exists(sourceDirectory)) {
+    Console.Error.WriteLine($"Source directory not found: {sourceDirectory}");
+    return 1;
+}
+
+if (Path.GetFullPath(sourceDirectory).TrimEnd(Path.DirectorySeparatorChar)
+    .Equals(Path.GetFullPath(outputDirectory).TrimEnd(Path.DirectorySeparatorChar), StringComparison.OrdinalIgnoreCase)) {
+    Console.Error.WriteLine("Source and output directories must be different.");
+    return 1;
+}
+
+var packageRelativePath = $"packages/update-{SanitizeVersion(arguments.TargetVersion!)}.zst";
+var packagePath = Path.Combine(outputDirectory, packageRelativePath.Replace('/', Path.DirectorySeparatorChar));
+Directory.CreateDirectory(Path.GetDirectoryName(packagePath)!);
+Directory.CreateDirectory(outputDirectory);
+
+var files = LoadFiles(sourceDirectory);
+var manifestFiles = files
+    .Select(file => new UpdateFile {
+        RelativePath = file.RelativePath,
+        NewChecksum = ComputeSha512(file.Content)
+    })
+    .ToList();
+
+var tempManifest = CreateManifest(arguments, manifestFiles, checksum: string.Empty);
+var tempPackage = CreatePackage(tempManifest, files);
+var finalManifest = CreateManifest(arguments, manifestFiles, ComputeSha512(tempPackage));
+var finalPackage = CreatePackage(finalManifest, files);
+
+await File.WriteAllBytesAsync(packagePath, finalPackage);
+
+var catalog = new UpdateCatalog {
+    LatestVersion = arguments.TargetVersion!,
+    MinRequiredVersion = arguments.MinSourceVersion,
+    LastUpdated = DateTime.UtcNow,
+    Entries = [
+        new UpdateCatalogEntry {
+            PackagePath = packageRelativePath.Replace('\\', '/'),
+            TargetVersion = arguments.TargetVersion!,
+            MinSourceVersion = arguments.MinSourceVersion!,
+            MaxSourceVersion = arguments.MaxSourceVersion,
+            IsCumulative = true,
+            PackageChecksum = ComputeSha512(finalPackage),
+            FileCount = files.Count,
+            CompressedSize = finalPackage.LongLength,
+            UncompressedSize = files.Sum(file => (long)file.Content.Length)
+        }
+    ]
+};
+
+var catalogPath = Path.Combine(outputDirectory, "catalog.json");
+await File.WriteAllTextAsync(
+    catalogPath,
+    JsonSerializer.Serialize(catalog, new JsonSerializerOptions { WriteIndented = true }));
+
+Console.WriteLine($"Catalog written: {catalogPath}");
+Console.WriteLine($"Package written: {packagePath}");
+Console.WriteLine($"Target version: {arguments.TargetVersion}");
+Console.WriteLine($"Min source version: {arguments.MinSourceVersion}");
+return 0;
+
+static UpdateManifest CreateManifest(BuilderArguments arguments, List<UpdateFile> files, string checksum)
+{
+    return new UpdateManifest {
+        TargetVersion = arguments.TargetVersion!,
+        MinSourceVersion = arguments.MinSourceVersion!,
+        MaxSourceVersion = arguments.MaxSourceVersion,
+        IsAnchor = false,
+        IsCumulative = true,
+        ChainDepth = 0,
+        Files = files,
+        Checksum = checksum,
+        CreatedAt = DateTime.UtcNow
+    };
+}
+
+static byte[] CreatePackage(UpdateManifest manifest, IReadOnlyList<UpdateFileContent> files)
+{
+    using var tarStream = new MemoryStream();
+    using (var tarWriter = new TarWriter(tarStream, leaveOpen: true)) {
+        WriteTarEntry(tarWriter, "manifest.json", JsonSerializer.SerializeToUtf8Bytes(manifest));
+
+        foreach (var file in files) {
+            WriteTarEntry(tarWriter, file.RelativePath, file.Content);
+        }
+    }
+
+    tarStream.Position = 0;
+
+    using var compressedStream = new MemoryStream();
+    using (var zstdStream = new CompressionStream(compressedStream, 3, leaveOpen: true)) {
+        tarStream.CopyTo(zstdStream);
+    }
+
+    compressedStream.Position = 0;
+    using var packageStream = new MemoryStream();
+    packageStream.Write([0x4D, 0x55, 0x50, 0x00]);
+    compressedStream.CopyTo(packageStream);
+    return packageStream.ToArray();
+}
+
+static void WriteTarEntry(TarWriter tarWriter, string relativePath, byte[] content)
+{
+    var entry = new PaxTarEntry(TarEntryType.RegularFile, relativePath.Replace('\\', '/')) {
+        DataStream = new MemoryStream(content)
+    };
+    tarWriter.WriteEntry(entry);
+}
+
+static List<UpdateFileContent> LoadFiles(string sourceDirectory)
+{
+    return Directory.GetFiles(sourceDirectory, "*", SearchOption.AllDirectories)
+        .Select(path => new UpdateFileContent(
+            Path.GetRelativePath(sourceDirectory, path),
+            File.ReadAllBytes(path)))
+        .OrderBy(file => file.RelativePath, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+}
+
+static string ComputeSha512(byte[] data)
+{
+    var hash = SHA512.HashData(data);
+    return Convert.ToHexString(hash).ToLowerInvariant();
+}
+
+static string SanitizeVersion(string version)
+{
+    var builder = new StringBuilder(version.Length);
+    foreach (var ch in version) {
+        builder.Append(char.IsLetterOrDigit(ch) ? ch : '-');
+    }
+
+    return builder.ToString();
+}
+
+internal sealed class BuilderArguments
+{
+    public string? SourceDirectory { get; private init; }
+    public string? OutputDirectory { get; private init; }
+    public string? TargetVersion { get; private init; }
+    public string? MinSourceVersion { get; private init; }
+    public string? MaxSourceVersion { get; private init; }
+
+    public bool IsValid =>
+        !string.IsNullOrWhiteSpace(SourceDirectory)
+        && !string.IsNullOrWhiteSpace(OutputDirectory)
+        && !string.IsNullOrWhiteSpace(TargetVersion)
+        && !string.IsNullOrWhiteSpace(MinSourceVersion);
+
+    public static BuilderArguments Parse(string[] args)
+    {
+        var values = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        for (var index = 0; index < args.Length; index += 2) {
+            if (!args[index].StartsWith("--", StringComparison.Ordinal) || index + 1 >= args.Length) {
+                return new BuilderArguments();
+            }
+
+            values[args[index]] = args[index + 1];
+        }
+
+        values.TryGetValue("--source-dir", out var sourceDirectory);
+        values.TryGetValue("--output-dir", out var outputDirectory);
+        values.TryGetValue("--target-version", out var targetVersion);
+        values.TryGetValue("--min-source-version", out var minSourceVersion);
+        values.TryGetValue("--max-source-version", out var maxSourceVersion);
+
+        return new BuilderArguments {
+            SourceDirectory = sourceDirectory,
+            OutputDirectory = outputDirectory,
+            TargetVersion = targetVersion,
+            MinSourceVersion = minSourceVersion,
+            MaxSourceVersion = maxSourceVersion
+        };
+    }
+
+    public static void PrintUsage()
+    {
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  TelegramSearchBot.UpdateBuilder --source-dir <dir> --output-dir <dir> --target-version <version> --min-source-version <version> [--max-source-version <version>]");
+    }
+}
+
+internal sealed record UpdateFileContent(string RelativePath, byte[] Content);
+
+internal sealed class UpdateFile
+{
+    public required string RelativePath { get; init; }
+    public required string NewChecksum { get; init; }
+}
+
+internal sealed class UpdateManifest
+{
+    public required string TargetVersion { get; init; }
+    public required string MinSourceVersion { get; init; }
+    public string? MaxSourceVersion { get; init; }
+    public bool IsAnchor { get; init; }
+    public bool IsCumulative { get; init; }
+    public int ChainDepth { get; init; }
+    public required List<UpdateFile> Files { get; init; }
+    public required string Checksum { get; init; }
+    public DateTime CreatedAt { get; init; }
+}
+
+internal sealed class UpdateCatalog
+{
+    public required string LatestVersion { get; init; }
+    public required List<UpdateCatalogEntry> Entries { get; init; }
+    public DateTime LastUpdated { get; init; }
+    public string? MinRequiredVersion { get; init; }
+}
+
+internal sealed class UpdateCatalogEntry
+{
+    public required string PackagePath { get; init; }
+    public required string TargetVersion { get; init; }
+    public required string MinSourceVersion { get; init; }
+    public string? MaxSourceVersion { get; init; }
+    public bool IsCumulative { get; init; }
+    public required string PackageChecksum { get; init; }
+    public int FileCount { get; init; }
+    public long CompressedSize { get; init; }
+    public long UncompressedSize { get; init; }
+}

--- a/TelegramSearchBot.UpdateBuilder/TelegramSearchBot.UpdateBuilder.csproj
+++ b/TelegramSearchBot.UpdateBuilder/TelegramSearchBot.UpdateBuilder.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.5" />
+  </ItemGroup>
+
+</Project>

--- a/TelegramSearchBot.sln
+++ b/TelegramSearchBot.sln
@@ -39,6 +39,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelegramSearchBot.Tokenizer
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelegramSearchBot.Tokenizer.Tests", "TelegramSearchBot.Tokenizer.Tests\TelegramSearchBot.Tokenizer.Tests.csproj", "{5FF9A80A-C87C-4E61-9986-831C9ACDEFDA}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TelegramSearchBot.UpdateBuilder", "TelegramSearchBot.UpdateBuilder\TelegramSearchBot.UpdateBuilder.csproj", "{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -193,6 +195,18 @@ Global
 		{5FF9A80A-C87C-4E61-9986-831C9ACDEFDA}.Release|x64.Build.0 = Release|Any CPU
 		{5FF9A80A-C87C-4E61-9986-831C9ACDEFDA}.Release|x86.ActiveCfg = Release|Any CPU
 		{5FF9A80A-C87C-4E61-9986-831C9ACDEFDA}.Release|x86.Build.0 = Release|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Debug|x64.Build.0 = Debug|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Debug|x86.Build.0 = Debug|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Release|x64.ActiveCfg = Release|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Release|x64.Build.0 = Release|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Release|x86.ActiveCfg = Release|Any CPU
+		{9DDA7740-77C6-4FE1-AA5E-7EF34C84776C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TelegramSearchBot/Controller/Help/HelpController.cs
+++ b/TelegramSearchBot/Controller/Help/HelpController.cs
@@ -38,6 +38,7 @@ namespace TelegramSearchBot.Controller.Help {
 ### 2. 全局管理员指令
 - **群组管理**: `设置管理群`/`取消管理群`
 - **Bilibili配置**: `/setbilicookie`, `/getbilicookie`
+- **应用更新**: `检查更新`, `更新`
 
 ## 三、自动功能
 1. **与LLM对话**: @机器人用户名

--- a/TelegramSearchBot/Controller/Manage/UpdateController.cs
+++ b/TelegramSearchBot/Controller/Manage/UpdateController.cs
@@ -1,0 +1,130 @@
+#if WINDOWS
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Telegram.Bot;
+using Telegram.Bot.Types;
+using TelegramSearchBot.Interface.Controller;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Service.AppUpdate;
+using TelegramSearchBot.Service.Manage;
+
+namespace TelegramSearchBot.Controller.Manage {
+    public class UpdateController : IOnUpdate {
+        private readonly ITelegramBotClient _botClient;
+        private readonly AdminService _adminService;
+        private readonly IHostApplicationLifetime _applicationLifetime;
+
+        public List<Type> Dependencies => new List<Type>() { typeof(AdminController) };
+
+        public UpdateController(
+            ITelegramBotClient botClient,
+            AdminService adminService,
+            IHostApplicationLifetime applicationLifetime) {
+            _botClient = botClient;
+            _adminService = adminService;
+            _applicationLifetime = applicationLifetime;
+        }
+
+        public async Task ExecuteAsync(PipelineContext p) {
+            var message = p.Update.Message;
+            if (message?.Text == null) {
+                return;
+            }
+
+            var text = message.Text.Trim();
+            if (!IsUpdateCommand(text)) {
+                return;
+            }
+
+            if (!await _adminService.IsNormalAdmin(message.From.Id)) {
+                await ReplyAsync(message, "❌ 权限不足：只有管理员才能使用更新指令。");
+                return;
+            }
+
+            switch (text.ToLowerInvariant()) {
+                case "/checkupdate":
+                case "/检查更新":
+                case "检查更新":
+                    await HandleCheckUpdateAsync(message);
+                    break;
+                case "/update":
+                case "/更新":
+                case "更新":
+                case "执行更新":
+                    await HandleStartUpdateAsync(message);
+                    break;
+            }
+        }
+
+        private static bool IsUpdateCommand(string text) {
+            return text.Equals("/checkupdate", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("/检查更新", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("检查更新", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("/update", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("/更新", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("更新", StringComparison.OrdinalIgnoreCase)
+                || text.Equals("执行更新", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private async Task HandleCheckUpdateAsync(Message message) {
+            var result = await SelfUpdateBootstrap.GetUpdateStatusAsync();
+            var sb = new StringBuilder();
+            sb.AppendLine("更新状态");
+            sb.AppendLine($"当前版本: {result.CurrentVersion}");
+            sb.AppendLine($"运行位置: {( result.RunningManagedInstall ? "独立安装目录" : "桥接启动实例" )}");
+            sb.AppendLine($"独立安装目录: {( result.ManagedInstallExists ? "已存在" : "尚未建立" )}");
+
+            if (!string.IsNullOrWhiteSpace(result.LatestVersion)) {
+                sb.AppendLine($"最新版本: {result.LatestVersion}");
+            }
+
+            switch (result.State) {
+                case ManagedUpdateState.UpToDate:
+                    sb.AppendLine("状态: 已是最新版本。");
+                    break;
+                case ManagedUpdateState.UpdateAvailable:
+                    sb.AppendLine($"状态: 可更新到 {result.TargetVersion ?? result.LatestVersion}。");
+                    sb.AppendLine("发送“更新”或 /update 立即开始升级。");
+                    break;
+                case ManagedUpdateState.UpdateUnavailable:
+                case ManagedUpdateState.NoPathFound:
+                    sb.AppendLine($"状态: {result.Message ?? "当前没有可用更新路径。"}");
+                    break;
+                default:
+                    sb.AppendLine($"状态: {result.Message ?? result.State.ToString()}");
+                    break;
+            }
+
+            await ReplyAsync(message, sb.ToString());
+        }
+
+        private async Task HandleStartUpdateAsync(Message message) {
+            var result = await SelfUpdateBootstrap.StartUpdateAsync();
+            string responseText = result.State switch {
+                ManagedUpdateState.UpdateScheduled => $"✅ 已开始准备更新到 {result.TargetVersion ?? result.LatestVersion}，机器人将退出并在更新后自动重启。",
+                ManagedUpdateState.UpToDate => "✅ 当前已经是最新版本，无需更新。",
+                ManagedUpdateState.UpdateAvailable => $"ℹ️ 已检测到新版本 {result.TargetVersion ?? result.LatestVersion}，但暂未成功调度更新。",
+                _ => $"❌ 无法启动更新：{result.Message ?? result.State.ToString()}"
+            };
+
+            await ReplyAsync(message, responseText);
+
+            if (result.ShouldStopApplication) {
+                _applicationLifetime.StopApplication();
+            }
+        }
+
+        private async Task ReplyAsync(Message message, string text) {
+            await _botClient.SendMessage(
+                chatId: message.Chat.Id,
+                text: text,
+                replyParameters: new Telegram.Bot.Types.ReplyParameters {
+                    MessageId = message.MessageId
+                });
+        }
+    }
+}
+#endif

--- a/TelegramSearchBot/Program.cs
+++ b/TelegramSearchBot/Program.cs
@@ -6,6 +6,7 @@ using Serilog.Events;
 using Serilog.Sinks.OpenTelemetry;
 using TelegramSearchBot.AppBootstrap;
 using TelegramSearchBot.Common;
+using TelegramSearchBot.Service.AppUpdate;
 
 namespace TelegramSearchBot {
     class Program {
@@ -30,6 +31,9 @@ namespace TelegramSearchBot {
             .CreateLogger();
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             if (args.Length == 0) {
+                if (await SelfUpdateBootstrap.TryApplyUpdateAsync(args)) {
+                    return;
+                }
                 await GeneralBootstrap.Startup(args); // Call async Startup
             } else if (args.Length >= 1) {
                 // 调用封装好的反射分发方法

--- a/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.Windows.cs
+++ b/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.Windows.cs
@@ -1,0 +1,397 @@
+#if WINDOWS
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Formats.Tar;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Reflection;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Serilog;
+using TelegramSearchBot.Common;
+using TelegramSearchBot.Helper;
+using ZstdSharp;
+
+namespace TelegramSearchBot.Service.AppUpdate;
+
+public static partial class SelfUpdateBootstrap
+{
+    private const string UpdaterFileName = "moder_update_updater.exe";
+    private static readonly JsonSerializerOptions JsonOptions = new() {
+        PropertyNameCaseInsensitive = true
+    };
+    private static readonly string ManagedInstallDirectory = Path.Combine(Env.WorkDir, "app");
+    private static readonly string ManagedExecutablePath = Path.Combine(ManagedInstallDirectory, "TelegramSearchBot.exe");
+    private static readonly string UpdaterCachePath = Path.Combine(Env.WorkDir, "updates", "tools", UpdaterFileName);
+
+    private static partial async Task<bool> TryApplyUpdateOnWindowsAsync(string[] args)
+    {
+        if (args.Length != 0 || !Env.EnableAutoUpdate) {
+            return false;
+        }
+
+        try {
+            if (TryHandOffToManagedInstall()) {
+                return true;
+            }
+
+            var currentVersion = ResolveCurrentVersion();
+            using var httpClient = HttpClientHelper.CreateProxyHttpClient();
+            var result = await CheckForUpdatesAsync(httpClient, currentVersion, CancellationToken.None);
+
+            if (result.Status == UpdateCheckStatus.UpToDate) {
+                return false;
+            }
+
+            if (result.Status != UpdateCheckStatus.UpdateAvailable || result.UpdateEntry is null) {
+                Log.Warning("自动更新不可用: {Message}", result.Message ?? $"status={result.Status}");
+                return false;
+            }
+
+            var updateEntry = result.UpdateEntry;
+            var updateRoot = Path.Combine(
+                Env.WorkDir,
+                "updates",
+                $"{SanitizeVersion(currentVersion)}-to-{SanitizeVersion(updateEntry.TargetVersion)}");
+            var stagingDir = Path.Combine(updateRoot, "staging");
+            var backupDir = Path.Combine(updateRoot, "backup");
+
+            ResetDirectory(stagingDir);
+            ResetDirectory(backupDir);
+
+            await using var packageStream = await DownloadStreamAsync(httpClient, updateEntry.PackagePath, CancellationToken.None);
+            await using var packageBuffer = new MemoryStream();
+            await packageStream.CopyToAsync(packageBuffer);
+            packageBuffer.Position = 0;
+
+            VerifyPackageChecksum(packageBuffer, updateEntry);
+            packageBuffer.Position = 0;
+            ExtractPackageToDirectory(packageBuffer, stagingDir);
+
+            var updaterPath = await DownloadUpdaterAsync(httpClient, CancellationToken.None);
+            SpawnUpdater(new UpdaterLaunchArgs {
+                UpdaterPath = updaterPath,
+                TargetPid = Environment.ProcessId,
+                TargetPath = ManagedExecutablePath,
+                StagingDir = stagingDir,
+                BackupDir = backupDir
+            });
+
+            Log.Information("检测到新版本 {TargetVersion}，已启动外部更新进程。", updateEntry.TargetVersion);
+            return true;
+        } catch (Exception ex) {
+            Log.Warning(ex, "自动更新检查失败，将继续启动当前程序。");
+            return false;
+        }
+    }
+
+    private static async Task<UpdateCheckResult> CheckForUpdatesAsync(HttpClient httpClient, string currentVersion, CancellationToken cancellationToken)
+    {
+        var catalog = await FetchCatalogAsync(httpClient, cancellationToken);
+
+        if (!Version.TryParse(currentVersion, out var current)) {
+            return UpdateCheckResult.NoPathFound($"Invalid current version: {currentVersion}");
+        }
+
+        if (!Version.TryParse(catalog.LatestVersion, out var latest)) {
+            return UpdateCheckResult.NoPathFound($"Invalid catalog latest version: {catalog.LatestVersion}");
+        }
+
+        if (current >= latest) {
+            return UpdateCheckResult.UpToDate(catalog.LatestVersion);
+        }
+
+        if (!string.IsNullOrWhiteSpace(catalog.MinRequiredVersion)
+            && Version.TryParse(catalog.MinRequiredVersion, out var minRequired)
+            && current < minRequired) {
+            return UpdateCheckResult.UpdateUnavailable(
+                catalog.LatestVersion,
+                $"Version {currentVersion} is below the minimum required version {catalog.MinRequiredVersion}. Reinstallation required.");
+        }
+
+        var updateEntry = catalog.Entries
+            .Where(entry => CanApplyEntry(current, entry))
+            .OrderByDescending(entry => Version.Parse(entry.TargetVersion))
+            .FirstOrDefault();
+
+        return updateEntry is null
+            ? UpdateCheckResult.NoPathFound($"No update path found from {currentVersion} to {catalog.LatestVersion}.")
+            : UpdateCheckResult.UpdateAvailable(catalog.LatestVersion, updateEntry);
+    }
+
+    private static async Task<UpdateCatalog> FetchCatalogAsync(HttpClient httpClient, CancellationToken cancellationToken)
+    {
+        using var response = await httpClient.GetAsync($"{Env.UpdateBaseUrl.TrimEnd('/')}/catalog.json", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        return await JsonSerializer.DeserializeAsync<UpdateCatalog>(stream, JsonOptions, cancellationToken)
+            ?? throw new InvalidDataException("Failed to deserialize update catalog.");
+    }
+
+    private static bool CanApplyEntry(Version currentVersion, UpdateCatalogEntry entry)
+    {
+        if (!Version.TryParse(entry.MinSourceVersion, out var minVersion)) {
+            return false;
+        }
+
+        Version? maxVersion = null;
+        if (!string.IsNullOrWhiteSpace(entry.MaxSourceVersion) && !Version.TryParse(entry.MaxSourceVersion, out maxVersion)) {
+            return false;
+        }
+
+        return currentVersion >= minVersion && (maxVersion is null || currentVersion <= maxVersion);
+    }
+
+    private static async Task<string> DownloadUpdaterAsync(HttpClient httpClient, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(UpdaterCachePath)!);
+        await using var updaterStream = await DownloadStreamAsync(httpClient, UpdaterFileName, cancellationToken);
+        await using var fileStream = File.Create(UpdaterCachePath);
+        await updaterStream.CopyToAsync(fileStream, cancellationToken);
+        return UpdaterCachePath;
+    }
+
+    private static async Task<Stream> DownloadStreamAsync(HttpClient httpClient, string relativePath, CancellationToken cancellationToken)
+    {
+        using var response = await httpClient.GetAsync($"{Env.UpdateBaseUrl.TrimEnd('/')}/{relativePath.TrimStart('/')}", cancellationToken);
+        response.EnsureSuccessStatusCode();
+        await using var sourceStream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var buffer = new MemoryStream();
+        await sourceStream.CopyToAsync(buffer, cancellationToken);
+        buffer.Position = 0;
+        return buffer;
+    }
+
+    private static void ExtractPackageToDirectory(Stream packageStream, string targetDirectory)
+    {
+        Directory.CreateDirectory(targetDirectory);
+
+        if (!ValidatePackageMagic(packageStream)) {
+            throw new InvalidDataException("Invalid Moder.Update package magic header.");
+        }
+
+        using var decompressed = DecompressPackage(packageStream);
+        using var tarReader = new TarReader(decompressed, leaveOpen: true);
+
+        while (tarReader.GetNextEntry() is { } entry) {
+            var normalizedPath = NormalizeTarPath(entry.Name);
+            if (string.Equals(normalizedPath, "manifest.json", StringComparison.OrdinalIgnoreCase)) {
+                continue;
+            }
+
+            if (entry.EntryType == TarEntryType.RegularFile || entry.EntryType == TarEntryType.V7RegularFile) {
+                var targetPath = Path.Combine(targetDirectory, normalizedPath);
+                var directory = Path.GetDirectoryName(targetPath);
+                if (directory is not null) {
+                    Directory.CreateDirectory(directory);
+                }
+
+                if (entry.DataStream is not null) {
+                    using var fileStream = File.Create(targetPath);
+                    entry.DataStream.CopyTo(fileStream);
+                }
+            } else if (entry.EntryType == TarEntryType.Directory) {
+                Directory.CreateDirectory(Path.Combine(targetDirectory, normalizedPath));
+            }
+        }
+    }
+
+    private static Stream DecompressPackage(Stream packageStream)
+    {
+        var output = new MemoryStream();
+        using (var decompressionStream = new DecompressionStream(packageStream, leaveOpen: true)) {
+            decompressionStream.CopyTo(output);
+        }
+
+        output.Position = 0;
+        return output;
+    }
+
+    private static bool ValidatePackageMagic(Stream packageStream)
+    {
+        Span<byte> buffer = stackalloc byte[4];
+        var bytesRead = packageStream.Read(buffer);
+        return bytesRead == 4
+            && buffer[0] == 0x4D
+            && buffer[1] == 0x55
+            && buffer[2] == 0x50
+            && buffer[3] == 0x00;
+    }
+
+    private static void SpawnUpdater(UpdaterLaunchArgs args)
+    {
+        var startInfo = new ProcessStartInfo {
+            FileName = args.UpdaterPath,
+            Arguments = BuildUpdaterArguments(args),
+            UseShellExecute = false,
+            CreateNoWindow = true,
+            CreateNewProcessGroup = true
+        };
+
+        var process = Process.Start(startInfo);
+        if (process is null) {
+            throw new InvalidOperationException("Failed to launch Moder.Update updater.");
+        }
+    }
+
+    private static string BuildUpdaterArguments(UpdaterLaunchArgs args)
+    {
+        var parts = new[] {
+            "--target-pid", args.TargetPid.ToString(),
+            "--target-path", Quote(args.TargetPath),
+            "--staging-dir", Quote(args.StagingDir),
+            "--wait-timeout", "30",
+            "--backup-dir", Quote(args.BackupDir)
+        };
+
+        return string.Join(' ', parts);
+    }
+
+    private static string Quote(string value)
+    {
+        if (value.Contains(' ') || value.Contains('"')) {
+            return $"\"{value.Replace("\"", "\\\"")}\"";
+        }
+
+        return value;
+    }
+
+    private static bool TryHandOffToManagedInstall()
+    {
+        if (!File.Exists(ManagedExecutablePath) || PathsEqual(Environment.ProcessPath, ManagedExecutablePath)) {
+            return false;
+        }
+
+        Process.Start(new ProcessStartInfo {
+            FileName = ManagedExecutablePath,
+            WorkingDirectory = ManagedInstallDirectory,
+            UseShellExecute = false
+        });
+        Log.Information("检测到独立安装目录，转交给 {ManagedExecutablePath} 启动。", ManagedExecutablePath);
+        return true;
+    }
+
+    private static string ResolveCurrentVersion()
+    {
+        var version = Assembly.GetExecutingAssembly().GetName().Version ?? new Version(0, 0, 0, 0);
+        return version.ToString(4);
+    }
+
+    private static void VerifyPackageChecksum(Stream packageStream, UpdateCatalogEntry updateEntry)
+    {
+        packageStream.Position = 0;
+        using var sha512 = SHA512.Create();
+        var actualChecksum = Convert.ToHexString(sha512.ComputeHash(packageStream));
+        if (!actualChecksum.Equals(updateEntry.PackageChecksum, StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidDataException(
+                $"更新包校验失败，期望 {updateEntry.PackageChecksum}，实际 {actualChecksum}。");
+        }
+
+        packageStream.Position = 0;
+    }
+
+    private static void ResetDirectory(string path)
+    {
+        if (Directory.Exists(path)) {
+            Directory.Delete(path, recursive: true);
+        }
+
+        Directory.CreateDirectory(path);
+    }
+
+    private static bool PathsEqual(string? left, string right)
+    {
+        if (string.IsNullOrWhiteSpace(left)) {
+            return false;
+        }
+
+        return string.Equals(
+            Path.GetFullPath(left),
+            Path.GetFullPath(right),
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string NormalizeTarPath(string path)
+    {
+        if (path.StartsWith("./", StringComparison.Ordinal)) {
+            path = path[2..];
+        }
+
+        return path.Replace('/', Path.DirectorySeparatorChar);
+    }
+
+    private static string SanitizeVersion(string version) => version.Replace('.', '_');
+
+    private sealed class UpdaterLaunchArgs
+    {
+        public required string UpdaterPath { get; init; }
+        public required int TargetPid { get; init; }
+        public required string TargetPath { get; init; }
+        public required string StagingDir { get; init; }
+        public required string BackupDir { get; init; }
+    }
+
+    private sealed class UpdateCatalog
+    {
+        public required string LatestVersion { get; init; }
+        public required List<UpdateCatalogEntry> Entries { get; init; }
+        public DateTime LastUpdated { get; init; }
+        public string? MinRequiredVersion { get; init; }
+    }
+
+    private sealed class UpdateCatalogEntry
+    {
+        public required string PackagePath { get; init; }
+        public required string TargetVersion { get; init; }
+        public required string MinSourceVersion { get; init; }
+        public string? MaxSourceVersion { get; init; }
+        public bool IsCumulative { get; init; }
+        public required string PackageChecksum { get; init; }
+        public long CompressedSize { get; init; }
+        public long UncompressedSize { get; init; }
+        public int FileCount { get; init; }
+    }
+
+    private sealed class UpdateCheckResult
+    {
+        public required UpdateCheckStatus Status { get; init; }
+        public string? LatestVersion { get; init; }
+        public UpdateCatalogEntry? UpdateEntry { get; init; }
+        public string? Message { get; init; }
+
+        public static UpdateCheckResult UpToDate(string latestVersion) => new() {
+            Status = UpdateCheckStatus.UpToDate,
+            LatestVersion = latestVersion
+        };
+
+        public static UpdateCheckResult UpdateAvailable(string latestVersion, UpdateCatalogEntry updateEntry) => new() {
+            Status = UpdateCheckStatus.UpdateAvailable,
+            LatestVersion = latestVersion,
+            UpdateEntry = updateEntry
+        };
+
+        public static UpdateCheckResult UpdateUnavailable(string latestVersion, string message) => new() {
+            Status = UpdateCheckStatus.UpdateUnavailable,
+            LatestVersion = latestVersion,
+            Message = message
+        };
+
+        public static UpdateCheckResult NoPathFound(string message) => new() {
+            Status = UpdateCheckStatus.NoPathFound,
+            Message = message
+        };
+    }
+
+    private enum UpdateCheckStatus
+    {
+        UpToDate,
+        UpdateAvailable,
+        UpdateUnavailable,
+        NoPathFound
+    }
+}
+#endif

--- a/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.Windows.cs
+++ b/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.Windows.cs
@@ -39,54 +39,50 @@ public static partial class SelfUpdateBootstrap
                 return true;
             }
 
-            var currentVersion = ResolveCurrentVersion();
-            using var httpClient = HttpClientHelper.CreateProxyHttpClient();
-            var result = await CheckForUpdatesAsync(httpClient, currentVersion, CancellationToken.None);
-
-            if (result.Status == UpdateCheckStatus.UpToDate) {
-                return false;
+            var result = await StartUpdateOnWindowsAsync();
+            if (result.State == ManagedUpdateState.UpdateScheduled) {
+                Log.Information("检测到新版本 {TargetVersion}，已启动外部更新进程。", result.TargetVersion);
+                return true;
             }
 
-            if (result.Status != UpdateCheckStatus.UpdateAvailable || result.UpdateEntry is null) {
-                Log.Warning("自动更新不可用: {Message}", result.Message ?? $"status={result.Status}");
-                return false;
+            if (result.State == ManagedUpdateState.NoPathFound || result.State == ManagedUpdateState.UpdateUnavailable) {
+                Log.Warning("自动更新不可用: {Message}", result.Message ?? $"state={result.State}");
             }
 
-            var updateEntry = result.UpdateEntry;
-            var updateRoot = Path.Combine(
-                Env.WorkDir,
-                "updates",
-                $"{SanitizeVersion(currentVersion)}-to-{SanitizeVersion(updateEntry.TargetVersion)}");
-            var stagingDir = Path.Combine(updateRoot, "staging");
-            var backupDir = Path.Combine(updateRoot, "backup");
-
-            ResetDirectory(stagingDir);
-            ResetDirectory(backupDir);
-
-            await using var packageStream = await DownloadStreamAsync(httpClient, updateEntry.PackagePath, CancellationToken.None);
-            await using var packageBuffer = new MemoryStream();
-            await packageStream.CopyToAsync(packageBuffer);
-            packageBuffer.Position = 0;
-
-            VerifyPackageChecksum(packageBuffer, updateEntry);
-            packageBuffer.Position = 0;
-            ExtractPackageToDirectory(packageBuffer, stagingDir);
-
-            var updaterPath = await DownloadUpdaterAsync(httpClient, CancellationToken.None);
-            SpawnUpdater(new UpdaterLaunchArgs {
-                UpdaterPath = updaterPath,
-                TargetPid = Environment.ProcessId,
-                TargetPath = ManagedExecutablePath,
-                StagingDir = stagingDir,
-                BackupDir = backupDir
-            });
-
-            Log.Information("检测到新版本 {TargetVersion}，已启动外部更新进程。", updateEntry.TargetVersion);
-            return true;
+            return false;
         } catch (Exception ex) {
             Log.Warning(ex, "自动更新检查失败，将继续启动当前程序。");
             return false;
         }
+    }
+
+    private static partial async Task<ManagedUpdateResult> GetUpdateStatusOnWindowsAsync()
+    {
+        var currentVersion = ResolveCurrentVersion();
+        using var httpClient = HttpClientHelper.CreateProxyHttpClient();
+        var result = await CheckForUpdatesAsync(httpClient, currentVersion, CancellationToken.None);
+        return ToManagedUpdateResult(result, currentVersion);
+    }
+
+    private static partial async Task<ManagedUpdateResult> StartUpdateOnWindowsAsync()
+    {
+        var currentVersion = ResolveCurrentVersion();
+        using var httpClient = HttpClientHelper.CreateProxyHttpClient();
+        var result = await CheckForUpdatesAsync(httpClient, currentVersion, CancellationToken.None);
+        if (result.Status != UpdateCheckStatus.UpdateAvailable || result.UpdateEntry is null) {
+            return ToManagedUpdateResult(result, currentVersion);
+        }
+
+        await PrepareUpdateAsync(httpClient, currentVersion, result.UpdateEntry, CancellationToken.None);
+        return new ManagedUpdateResult {
+            State = ManagedUpdateState.UpdateScheduled,
+            CurrentVersion = currentVersion,
+            LatestVersion = result.LatestVersion,
+            TargetVersion = result.UpdateEntry.TargetVersion,
+            ManagedInstallExists = File.Exists(ManagedExecutablePath),
+            RunningManagedInstall = PathsEqual(Environment.ProcessPath, ManagedExecutablePath),
+            Message = $"已计划更新到 {result.UpdateEntry.TargetVersion}。"
+        };
     }
 
     private static async Task<UpdateCheckResult> CheckForUpdatesAsync(HttpClient httpClient, string currentVersion, CancellationToken cancellationToken)
@@ -121,6 +117,59 @@ public static partial class SelfUpdateBootstrap
         return updateEntry is null
             ? UpdateCheckResult.NoPathFound($"No update path found from {currentVersion} to {catalog.LatestVersion}.")
             : UpdateCheckResult.UpdateAvailable(catalog.LatestVersion, updateEntry);
+    }
+
+    private static ManagedUpdateResult ToManagedUpdateResult(UpdateCheckResult result, string currentVersion)
+    {
+        return new ManagedUpdateResult {
+            State = result.Status switch {
+                UpdateCheckStatus.UpToDate => ManagedUpdateState.UpToDate,
+                UpdateCheckStatus.UpdateAvailable => ManagedUpdateState.UpdateAvailable,
+                UpdateCheckStatus.UpdateUnavailable => ManagedUpdateState.UpdateUnavailable,
+                _ => ManagedUpdateState.NoPathFound
+            },
+            CurrentVersion = currentVersion,
+            LatestVersion = result.LatestVersion,
+            TargetVersion = result.UpdateEntry?.TargetVersion,
+            Message = result.Message,
+            ManagedInstallExists = File.Exists(ManagedExecutablePath),
+            RunningManagedInstall = PathsEqual(Environment.ProcessPath, ManagedExecutablePath)
+        };
+    }
+
+    private static async Task PrepareUpdateAsync(
+        HttpClient httpClient,
+        string currentVersion,
+        UpdateCatalogEntry updateEntry,
+        CancellationToken cancellationToken)
+    {
+        var updateRoot = Path.Combine(
+            Env.WorkDir,
+            "updates",
+            $"{SanitizeVersion(currentVersion)}-to-{SanitizeVersion(updateEntry.TargetVersion)}");
+        var stagingDir = Path.Combine(updateRoot, "staging");
+        var backupDir = Path.Combine(updateRoot, "backup");
+
+        ResetDirectory(stagingDir);
+        ResetDirectory(backupDir);
+
+        await using var packageStream = await DownloadStreamAsync(httpClient, updateEntry.PackagePath, cancellationToken);
+        await using var packageBuffer = new MemoryStream();
+        await packageStream.CopyToAsync(packageBuffer, cancellationToken);
+        packageBuffer.Position = 0;
+
+        VerifyPackageChecksum(packageBuffer, updateEntry);
+        packageBuffer.Position = 0;
+        ExtractPackageToDirectory(packageBuffer, stagingDir);
+
+        var updaterPath = await DownloadUpdaterAsync(httpClient, cancellationToken);
+        SpawnUpdater(new UpdaterLaunchArgs {
+            UpdaterPath = updaterPath,
+            TargetPid = Environment.ProcessId,
+            TargetPath = ManagedExecutablePath,
+            StagingDir = stagingDir,
+            BackupDir = backupDir
+        });
     }
 
     private static async Task<UpdateCatalog> FetchCatalogAsync(HttpClient httpClient, CancellationToken cancellationToken)
@@ -244,7 +293,7 @@ public static partial class SelfUpdateBootstrap
             "--target-pid", args.TargetPid.ToString(),
             "--target-path", Quote(args.TargetPath),
             "--staging-dir", Quote(args.StagingDir),
-            "--wait-timeout", "30",
+            "--wait-timeout", "60",
             "--backup-dir", Quote(args.BackupDir)
         };
 

--- a/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.Windows.cs
+++ b/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.Windows.cs
@@ -177,8 +177,10 @@ public static partial class SelfUpdateBootstrap
         using var response = await httpClient.GetAsync($"{Env.UpdateBaseUrl.TrimEnd('/')}/catalog.json", cancellationToken);
         response.EnsureSuccessStatusCode();
         await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
-        return await JsonSerializer.DeserializeAsync<UpdateCatalog>(stream, JsonOptions, cancellationToken)
+        var catalog = await JsonSerializer.DeserializeAsync<UpdateCatalog>(stream, JsonOptions, cancellationToken)
             ?? throw new InvalidDataException("Failed to deserialize update catalog.");
+        UpdateCatalogCache.UpdaterChecksum = catalog.UpdaterChecksum;
+        return catalog;
     }
 
     private static bool CanApplyEntry(Version currentVersion, UpdateCatalogEntry entry)
@@ -199,8 +201,12 @@ public static partial class SelfUpdateBootstrap
     {
         Directory.CreateDirectory(Path.GetDirectoryName(UpdaterCachePath)!);
         await using var updaterStream = await DownloadStreamAsync(httpClient, UpdaterFileName, cancellationToken);
+        await using var updaterBuffer = new MemoryStream();
+        await updaterStream.CopyToAsync(updaterBuffer, cancellationToken);
+        VerifyUpdaterChecksum(updaterBuffer);
+        updaterBuffer.Position = 0;
         await using var fileStream = File.Create(UpdaterCachePath);
-        await updaterStream.CopyToAsync(fileStream, cancellationToken);
+        await updaterBuffer.CopyToAsync(fileStream, cancellationToken);
         return UpdaterCachePath;
     }
 
@@ -218,6 +224,9 @@ public static partial class SelfUpdateBootstrap
     private static void ExtractPackageToDirectory(Stream packageStream, string targetDirectory)
     {
         Directory.CreateDirectory(targetDirectory);
+        var targetDirectoryPath = Path.GetFullPath(targetDirectory);
+        var directoryPrefix = targetDirectoryPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            + Path.DirectorySeparatorChar;
 
         if (!ValidatePackageMagic(packageStream)) {
             throw new InvalidDataException("Invalid Moder.Update package magic header.");
@@ -232,8 +241,13 @@ public static partial class SelfUpdateBootstrap
                 continue;
             }
 
+            if (Path.IsPathRooted(normalizedPath)) {
+                throw new InvalidDataException($"Package entry '{entry.Name}' is rooted and cannot be extracted.");
+            }
+
             if (entry.EntryType == TarEntryType.RegularFile || entry.EntryType == TarEntryType.V7RegularFile) {
-                var targetPath = Path.Combine(targetDirectory, normalizedPath);
+                var targetPath = Path.GetFullPath(Path.Combine(targetDirectoryPath, normalizedPath));
+                EnsurePathWithinDirectory(targetPath, directoryPrefix, entry.Name);
                 var directory = Path.GetDirectoryName(targetPath);
                 if (directory is not null) {
                     Directory.CreateDirectory(directory);
@@ -244,7 +258,9 @@ public static partial class SelfUpdateBootstrap
                     entry.DataStream.CopyTo(fileStream);
                 }
             } else if (entry.EntryType == TarEntryType.Directory) {
-                Directory.CreateDirectory(Path.Combine(targetDirectory, normalizedPath));
+                var directoryPath = Path.GetFullPath(Path.Combine(targetDirectoryPath, normalizedPath));
+                EnsurePathWithinDirectory(directoryPath, directoryPrefix, entry.Name);
+                Directory.CreateDirectory(directoryPath);
             }
         }
     }
@@ -343,6 +359,23 @@ public static partial class SelfUpdateBootstrap
         packageStream.Position = 0;
     }
 
+    private static void VerifyUpdaterChecksum(Stream updaterStream)
+    {
+        updaterStream.Position = 0;
+        using var sha512 = SHA512.Create();
+        var actualChecksum = Convert.ToHexString(sha512.ComputeHash(updaterStream)).ToLowerInvariant();
+        if (string.IsNullOrWhiteSpace(UpdateCatalogCache.UpdaterChecksum)) {
+            throw new InvalidDataException("更新目录未提供 updater 校验值，已拒绝执行外部更新器。");
+        }
+
+        if (!actualChecksum.Equals(UpdateCatalogCache.UpdaterChecksum, StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidDataException(
+                $"updater 校验失败，期望 {UpdateCatalogCache.UpdaterChecksum}，实际 {actualChecksum}。");
+        }
+
+        updaterStream.Position = 0;
+    }
+
     private static void ResetDirectory(string path)
     {
         if (Directory.Exists(path)) {
@@ -375,6 +408,13 @@ public static partial class SelfUpdateBootstrap
 
     private static string SanitizeVersion(string version) => version.Replace('.', '_');
 
+    private static void EnsurePathWithinDirectory(string targetPath, string directoryPrefix, string entryName)
+    {
+        if (!targetPath.StartsWith(directoryPrefix, StringComparison.OrdinalIgnoreCase)) {
+            throw new InvalidDataException($"Package entry '{entryName}' would escape the staging directory.");
+        }
+    }
+
     private sealed class UpdaterLaunchArgs
     {
         public required string UpdaterPath { get; init; }
@@ -390,6 +430,7 @@ public static partial class SelfUpdateBootstrap
         public required List<UpdateCatalogEntry> Entries { get; init; }
         public DateTime LastUpdated { get; init; }
         public string? MinRequiredVersion { get; init; }
+        public string? UpdaterChecksum { get; init; }
     }
 
     private sealed class UpdateCatalogEntry
@@ -441,6 +482,11 @@ public static partial class SelfUpdateBootstrap
         UpdateAvailable,
         UpdateUnavailable,
         NoPathFound
+    }
+
+    private static class UpdateCatalogCache
+    {
+        public static string? UpdaterChecksum { get; set; }
     }
 }
 #endif

--- a/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.cs
+++ b/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.cs
@@ -2,6 +2,28 @@ using System.Threading.Tasks;
 
 namespace TelegramSearchBot.Service.AppUpdate;
 
+public enum ManagedUpdateState
+{
+    Unsupported,
+    UpToDate,
+    UpdateAvailable,
+    UpdateScheduled,
+    UpdateUnavailable,
+    NoPathFound
+}
+
+public sealed class ManagedUpdateResult
+{
+    public required ManagedUpdateState State { get; init; }
+    public string CurrentVersion { get; init; } = "0.0.0.0";
+    public string? LatestVersion { get; init; }
+    public string? TargetVersion { get; init; }
+    public string? Message { get; init; }
+    public bool ManagedInstallExists { get; init; }
+    public bool RunningManagedInstall { get; init; }
+    public bool ShouldStopApplication => State == ManagedUpdateState.UpdateScheduled;
+}
+
 public static partial class SelfUpdateBootstrap
 {
     public static Task<bool> TryApplyUpdateAsync(string[] args)
@@ -13,7 +35,33 @@ public static partial class SelfUpdateBootstrap
 #endif
     }
 
+    public static Task<ManagedUpdateResult> GetUpdateStatusAsync()
+    {
+#if WINDOWS
+        return GetUpdateStatusOnWindowsAsync();
+#else
+        return Task.FromResult(new ManagedUpdateResult {
+            State = ManagedUpdateState.Unsupported,
+            Message = "当前平台不支持内置更新流程。"
+        });
+#endif
+    }
+
+    public static Task<ManagedUpdateResult> StartUpdateAsync()
+    {
+#if WINDOWS
+        return StartUpdateOnWindowsAsync();
+#else
+        return Task.FromResult(new ManagedUpdateResult {
+            State = ManagedUpdateState.Unsupported,
+            Message = "当前平台不支持内置更新流程。"
+        });
+#endif
+    }
+
 #if WINDOWS
     private static partial Task<bool> TryApplyUpdateOnWindowsAsync(string[] args);
+    private static partial Task<ManagedUpdateResult> GetUpdateStatusOnWindowsAsync();
+    private static partial Task<ManagedUpdateResult> StartUpdateOnWindowsAsync();
 #endif
 }

--- a/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.cs
+++ b/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace TelegramSearchBot.Service.AppUpdate;
+
+public static partial class SelfUpdateBootstrap
+{
+    public static Task<bool> TryApplyUpdateAsync(string[] args)
+    {
+#if WINDOWS
+        return TryApplyUpdateOnWindowsAsync(args);
+#else
+        return Task.FromResult(false);
+#endif
+    }
+
+#if WINDOWS
+    private static partial Task<bool> TryApplyUpdateOnWindowsAsync(string[] args);
+#endif
+}

--- a/TelegramSearchBot/TelegramSearchBot.csproj
+++ b/TelegramSearchBot/TelegramSearchBot.csproj
@@ -6,7 +6,9 @@
     <PublishReadyToRun>true</PublishReadyToRun>
     <Nullable>warnings</Nullable>
     <StartupObject>TelegramSearchBot.Program</StartupObject>
-    <Version>0.0.0</Version>
+    <Version Condition="'$(BUILD_VERSION)' != ''">$(BUILD_VERSION)</Version>
+    <Version Condition="'$(BUILD_VERSION)' == ''">0.0.0</Version>
+    <InformationalVersion>$(Version)</InformationalVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">

--- a/TelegramSearchBot/TelegramSearchBot.csproj
+++ b/TelegramSearchBot/TelegramSearchBot.csproj
@@ -6,6 +6,7 @@
     <PublishReadyToRun>true</PublishReadyToRun>
     <Nullable>warnings</Nullable>
     <StartupObject>TelegramSearchBot.Program</StartupObject>
+    <Version>0.0.0</Version>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(OS)' == 'Windows_NT'">
@@ -89,6 +90,7 @@
     <PackageReference Include="FaissNet" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ScottPlot" Version="5.1.57" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TelegramSearchBot.Common\TelegramSearchBot.Common.csproj" />


### PR DESCRIPTION
## Summary
- replace the startup update flow with a Moder.Update-compatible managed install path under %LOCALAPPDATA%\\TelegramSearchBot\\app
- add TelegramSearchBot.UpdateBuilder and publish catalog.json, cumulative packages, and the updater binary alongside the preserved ClickOnce bridge
- document the new auto-update settings and release flow

## Validation
- dotnet build TelegramSearchBot.sln -c Release
- dotnet test TelegramSearchBot.sln -c Release --no-build
- smoke-tested TelegramSearchBot.UpdateBuilder package generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic update capability. Initial installations remain browser-deployed; subsequent updates are managed independently in a local directory.
  * Introduced new configuration options to control auto-updates and specify custom update sources.

* **Documentation**
  * Updated build and installation guides to reflect the new publishing pipeline and standalone update mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->