### PR TITLE
fix: add helper runtime identifiers

### DIFF
--- a/TelegramSearchBot.LLMAgent/TelegramSearchBot.LLMAgent.csproj
+++ b/TelegramSearchBot.LLMAgent/TelegramSearchBot.LLMAgent.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/TelegramSearchBot.SubAgent/TelegramSearchBot.SubAgent.csproj
+++ b/TelegramSearchBot.SubAgent/TelegramSearchBot.SubAgent.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
- add explicit RuntimeIdentifiers to TelegramSearchBot.LLMAgent and TelegramSearchBot.SubAgent
- fix win-x64 publish on the post-merge release workflow by ensuring restore produces runtime assets for both helper executables

## Validation
- dotnet restore TelegramSearchBot.sln /p:BuildWithNetFrameworkHostedCompiler=true
- dotnet build TelegramSearchBot.sln -c Release --no-restore
- dotnet test TelegramSearchBot.sln -c Release --no-build
- dotnet publish .\\TelegramSearchBot\\TelegramSearchBot.csproj -c Release -r win-x64 --self-contained true --no-restore /p:Version=2026.04.23.1000 /p:PublishSingleFile=false -o .\\artifacts\\standalone

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded platform-specific build support by adding explicit configuration for Windows and Linux 64-bit environments, ensuring optimized builds and deployments across both platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->