### PR TITLE
fix: remove unsupported telegram blockquotes

### DIFF
--- a/TelegramSearchBot.Test/Helper/MessageFormatHelperTests.cs
+++ b/TelegramSearchBot.Test/Helper/MessageFormatHelperTests.cs
@@ -40,7 +40,7 @@ namespace TelegramSearchBot.Test.Helper {
         }
 
         [Fact]
-        public void ConvertMarkdownToTelegramHtml_WithCollapsedIterations_EmitsExpandableBlockquote() {
+        public void ConvertMarkdownToTelegramHtml_WithCollapsedIterations_EmitsSpoiler() {
             var markdown = """
 :::tg-expandable-blockquote
 第一轮分析
@@ -53,9 +53,25 @@ namespace TelegramSearchBot.Test.Helper {
 
             var html = MessageFormatHelper.ConvertMarkdownToTelegramHtml(markdown);
 
-            Assert.Contains("<blockquote expandable>", html);
+            Assert.Contains("<tg-spoiler>", html);
             Assert.Contains("<code>search_messages</code>", html);
             Assert.Contains("最终回答：可以把中间过程折叠起来。", html);
+            Assert.DoesNotContain("<blockquote", html);
+        }
+
+        [Fact]
+        public void ConvertMarkdownToTelegramHtml_WithBlockquote_DoesNotEmitUnsupportedBlockquoteTag() {
+            var markdown = """
+> 第一行引用
+>
+> 第二行引用
+""";
+
+            var html = MessageFormatHelper.ConvertMarkdownToTelegramHtml(markdown);
+
+            Assert.Contains("&gt; 第一行引用", html);
+            Assert.Contains("&gt; 第二行引用", html);
+            Assert.DoesNotContain("<blockquote", html);
         }
 
         [Fact]

--- a/TelegramSearchBot/Helper/MessageFormatHelper.cs
+++ b/TelegramSearchBot/Helper/MessageFormatHelper.cs
@@ -61,18 +61,18 @@ namespace TelegramSearchBot.Helper {
                         case "h1": case "h2": case "h3": case "h4": case "h5": case "h6": builder.Append("<b>"); ProcessChildren(node, builder); builder.Append("</b>\n"); break;
                         case "ul": case "ol": ProcessList(node, builder, tagName == "ol" ? 1 : 0); builder.Append("\n"); break;
                         case "blockquote":
-                            builder.Append(node.Attributes["expandable"] != null ? "<blockquote expandable>" : "<blockquote>");
-                            ProcessChildren(node, builder);
-                            builder.Append("</blockquote>");
+                            if (node.Attributes["expandable"] != null) {
+                                AppendSpoilerBlock(node, builder);
+                            } else {
+                                AppendQuotedBlock(node, builder);
+                            }
                             break;
                         case "span":
                         case "div":
                         case "font":
                         case "img":
                             if (tagName == "div" && HasCssClass(node, ExpandableBlockquoteContainerClass)) {
-                                builder.Append("<blockquote expandable>");
-                                ProcessChildren(node, builder);
-                                builder.Append("</blockquote>");
+                                AppendSpoilerBlock(node, builder);
                                 break;
                             }
                             if (tagName == "img") {
@@ -102,6 +102,37 @@ namespace TelegramSearchBot.Helper {
             return classValue
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries)
                 .Any(x => string.Equals(x, cssClass, StringComparison.Ordinal));
+        }
+
+        private static void AppendSpoilerBlock(HtmlNode node, StringBuilder builder) {
+            builder.Append("<tg-spoiler>");
+            ProcessChildren(node, builder);
+            builder.Append("</tg-spoiler>");
+        }
+
+        private static void AppendQuotedBlock(HtmlNode node, StringBuilder builder) {
+            var quotedContent = new StringBuilder();
+            ProcessChildren(node, quotedContent);
+
+            var normalized = quotedContent
+                .ToString()
+                .Trim('\r', '\n');
+
+            if (string.IsNullOrWhiteSpace(normalized)) {
+                return;
+            }
+
+            var lines = normalized.Replace("\r\n", "\n").Split('\n');
+            foreach (var line in lines) {
+                if (string.IsNullOrWhiteSpace(line)) {
+                    builder.Append('\n');
+                    continue;
+                }
+
+                builder.Append("&gt; ");
+                builder.Append(line.TrimEnd());
+                builder.Append('\n');
+            }
         }
 
         private static string EncodeTelegramHtmlText(string text) {


### PR DESCRIPTION
## Summary
- stop emitting unsupported <blockquote> tags for Telegram HTML messages
- render collapsed intermediate output with tg-spoiler and plain blockquotes as quoted text lines
- add regression tests for both collapsed and regular blockquote conversion

## Validation
- dotnet build TelegramSearchBot.sln -c Release
- dotnet test TelegramSearchBot.sln -c Release --no-build