### PR TITLE
fix: collapse intermediate output to summary

### DIFF
--- a/TelegramSearchBot.Test/Helper/MessageFormatHelperTests.cs
+++ b/TelegramSearchBot.Test/Helper/MessageFormatHelperTests.cs
@@ -33,30 +33,27 @@ namespace TelegramSearchBot.Test.Helper {
 
             var result = MessageFormatHelper.CollapseLlmIntermediateIterations(input);
 
-            Assert.Contains(":::tg-expandable-blockquote", result);
-            Assert.Contains("第一轮分析", result);
+            Assert.Contains("已折叠前面的中间过程和 1 次工具调用", result);
             Assert.Contains("🔧 `search_messages` [query: telegram collapse]", result);
+            Assert.DoesNotContain("第一轮分析", result);
             Assert.EndsWith("最终回答：可以把中间过程折叠起来。", result);
         }
 
         [Fact]
-        public void ConvertMarkdownToTelegramHtml_WithCollapsedIterations_EmitsSpoiler() {
+        public void ConvertMarkdownToTelegramHtml_WithCollapsedIterations_EmitsCompactSummary() {
             var markdown = """
-:::tg-expandable-blockquote
-第一轮分析
-
-🔧 `search_messages` [query: telegram collapse]
-:::
+💭 已折叠前面的中间过程和 1 次工具调用（最近一次：🔧 `search_messages` [query: telegram collapse]）。
 
 最终回答：可以把中间过程折叠起来。
 """;
 
             var html = MessageFormatHelper.ConvertMarkdownToTelegramHtml(markdown);
 
-            Assert.Contains("<tg-spoiler>", html);
+            Assert.Contains("已折叠前面的中间过程和 1 次工具调用", html);
             Assert.Contains("<code>search_messages</code>", html);
             Assert.Contains("最终回答：可以把中间过程折叠起来。", html);
             Assert.DoesNotContain("<blockquote", html);
+            Assert.DoesNotContain("<tg-spoiler>", html);
         }
 
         [Fact]

--- a/TelegramSearchBot/Helper/MessageFormatHelper.cs
+++ b/TelegramSearchBot/Helper/MessageFormatHelper.cs
@@ -61,18 +61,14 @@ namespace TelegramSearchBot.Helper {
                         case "h1": case "h2": case "h3": case "h4": case "h5": case "h6": builder.Append("<b>"); ProcessChildren(node, builder); builder.Append("</b>\n"); break;
                         case "ul": case "ol": ProcessList(node, builder, tagName == "ol" ? 1 : 0); builder.Append("\n"); break;
                         case "blockquote":
-                            if (node.Attributes["expandable"] != null) {
-                                AppendSpoilerBlock(node, builder);
-                            } else {
-                                AppendQuotedBlock(node, builder);
-                            }
+                            AppendQuotedBlock(node, builder);
                             break;
                         case "span":
                         case "div":
                         case "font":
                         case "img":
                             if (tagName == "div" && HasCssClass(node, ExpandableBlockquoteContainerClass)) {
-                                AppendSpoilerBlock(node, builder);
+                                AppendQuotedBlock(node, builder);
                                 break;
                             }
                             if (tagName == "img") {
@@ -102,12 +98,6 @@ namespace TelegramSearchBot.Helper {
             return classValue
                 .Split(' ', StringSplitOptions.RemoveEmptyEntries)
                 .Any(x => string.Equals(x, cssClass, StringComparison.Ordinal));
-        }
-
-        private static void AppendSpoilerBlock(HtmlNode node, StringBuilder builder) {
-            builder.Append("<tg-spoiler>");
-            ProcessChildren(node, builder);
-            builder.Append("</tg-spoiler>");
         }
 
         private static void AppendQuotedBlock(HtmlNode node, StringBuilder builder) {
@@ -293,13 +283,11 @@ namespace TelegramSearchBot.Helper {
                 return markdown;
             }
 
-            return $"""
-:::{ExpandableBlockquoteContainerClass}
-{collapsedPrefix}
-:::
+            var lastToolCall = lastMatch.Value.Trim();
+            var toolCallCountText = matches.Count == 1 ? "1 次工具调用" : $"{matches.Count} 次工具调用";
+            var collapsedSummary = $"💭 已折叠前面的中间过程和 {toolCallCountText}（最近一次：{lastToolCall}）。";
 
-{visibleSuffix}
-""";
+            return $"{collapsedSummary}\n\n{visibleSuffix}";
         }
 
         public static string EscapeMarkdownV2(string text) {


### PR DESCRIPTION
## Summary
- replace the previous hidden/spoiler-style collapse with a compact one-line summary of intermediate iterations
- keep unsupported Telegram blockquotes out of the generated HTML
- update regression tests to cover compact collapsed output and normal blockquotes

## Validation
- dotnet build TelegramSearchBot.sln -c Release
- dotnet test TelegramSearchBot.sln -c Release --no-build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display of collapsed LLM intermediate iterations: now shows a compact one-line summary indicating the number of tool calls and recent activity, replacing the previous expandable format.
  * Enhanced HTML conversion for blockquote elements with consistent rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->