### PR TITLE
fix: harden parallel release workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,12 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  group: push-release-${{ github.ref }}
+  cancel-in-progress: false
+
 env:
+  B2_CLI_VERSION: '4.6.0'
   LEGACY_BRIDGE_VERSION: '2026.04.23.553'
   LEGACY_BRIDGE_MARKER: 'legacy-clickonce-bridge-version.txt'
   MODER_UPDATE_COMMIT: 'd547c9905d0cb706aa163e418ab5ef424a14dc9c'
@@ -25,7 +30,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Compute release versions
@@ -46,16 +51,22 @@ jobs:
         B2_APPKEY_ID: ${{ secrets.B2_APPKEY_ID }}
         B2_APPKEY: ${{ secrets.B2_APPKEY }}
       run: |
-        pip install --quiet --cache-dir C:\pip-cache b2
+        pip install --quiet --cache-dir C:\pip-cache "b2==$env:B2_CLI_VERSION"
         b2 account authorize $env:B2_APPKEY_ID $env:B2_APPKEY --quiet
+        if ($LASTEXITCODE -ne 0) {
+          throw "b2 account authorize failed with exit code $LASTEXITCODE."
+        }
         $markerPath = "TelegramSearchBot/$env:LEGACY_BRIDGE_MARKER"
         $existingMarker = b2 ls --recursive "b2://$env:B2_BUCKET/$markerPath"
+        if ($LASTEXITCODE -ne 0) {
+          throw "b2 ls failed while checking bridge marker with exit code $LASTEXITCODE."
+        }
         if ([string]::IsNullOrWhiteSpace($existingMarker)) {
           "publish-bridge=true" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         } else {
           "publish-bridge=false" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
         }
-        b2 clear-account
+        b2 account clear
 
   validate:
     needs: prepare
@@ -324,7 +335,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: '3.9'
     - name: Download update feed artifact
@@ -433,8 +444,11 @@ jobs:
           }
         }
 
-        pip install --quiet --cache-dir C:\pip-cache b2
+        pip install --quiet --cache-dir C:\pip-cache "b2==$env:B2_CLI_VERSION"
         b2 account authorize $env:B2_APPKEY_ID $env:B2_APPKEY --quiet
+        if ($LASTEXITCODE -ne 0) {
+          throw "b2 account authorize failed with exit code $LASTEXITCODE."
+        }
 
         if ("${{ needs.prepare.outputs.publish-bridge }}" -eq "true") {
           $bridgeRoot = (Resolve-Path .\artifacts\legacy-bridge).Path
@@ -456,7 +470,7 @@ jobs:
         Prune-B2PackageVersions -KeepRelativePaths $packageFiles
         Prune-B2FileVersions -RelativePath 'TelegramSearchBot/moder_update_updater.exe'
         Prune-B2FileVersions -RelativePath 'TelegramSearchBot/catalog.json'
-        b2 clear-account
+        b2 account clear
     - name: Publish full package to GitHub Release
       uses: softprops/action-gh-release@v2
       with:

--- a/Docs/Build_and_Test_Guide.md
+++ b/Docs/Build_and_Test_Guide.md
@@ -238,6 +238,7 @@ jobs:
 - 保留根目录中的最终 ClickOnce bridge，供旧安装版本过渡到新更新链路。
 - 每次主分支发布都会生成 `catalog.json`、`packages/` 和 `moder_update_updater.exe`，供 `%LOCALAPPDATA%\TelegramSearchBot\app` 中的独立安装目录继续使用 Moder.Update 协议升级。
 - `push.yml` 会把校验、`telegram-bot-api` 构建、Moder.Update updater 构建、独立包构建和桥接包构建尽量拆成并行 job，最后再统一上传到 Backblaze B2 与 GitHub Releases。
+- 同一分支上的发布运行会通过 workflow `concurrency` 串行化，避免并发发布互相覆盖 B2 包或 Release 产物。
 - 同一条发布流水线会在新文件上传成功后裁剪 Backblaze B2 上重复或过期的更新包版本，并把 `TelegramSearchBot-win-x64-full-<version>.zip` 全量包上传到 GitHub Releases，便于手动分发和回滚。
 
 ### 监控与日志


### PR DESCRIPTION
## Summary
- add workflow concurrency so overlapping release runs on the same ref are serialized
- pin the Backblaze B2 CLI version and update the workflow to use the v4 account clear command
- fail bridge marker lookup on B2 client errors and upgrade setup-python steps to v5