### PR TITLE
fix: update package checksum computed from wrong package bytes

### DIFF
--- a/TelegramSearchBot.UpdateBuilder/Program.cs
+++ b/TelegramSearchBot.UpdateBuilder/Program.cs
@@ -242,7 +242,7 @@ static (byte[] PackageBytes, string Checksum) BuildPackageFile(
         })
         .ToList();
 
-    var tempManifest = new UpdateManifest
+    var manifest = new UpdateManifest
     {
         TargetVersion = toVersion,
         MinSourceVersion = fromVersion,
@@ -255,24 +255,9 @@ static (byte[] PackageBytes, string Checksum) BuildPackageFile(
         CreatedAt = DateTime.UtcNow
     };
 
-    var tempBytes = CreatePackage(tempManifest, files);
-    var finalChecksum = ComputeSha512(tempBytes);
-
-    var finalManifest = new UpdateManifest
-    {
-        TargetVersion = toVersion,
-        MinSourceVersion = fromVersion,
-        MaxSourceVersion = isCumulative ? null : fromVersion,
-        IsAnchor = isAnchor,
-        IsCumulative = isCumulative,
-        ChainDepth = chainDepth,
-        Files = manifestFiles,
-        Checksum = finalChecksum,
-        CreatedAt = DateTime.UtcNow
-    };
-
-    var finalBytes = CreatePackage(finalManifest, files);
-    return (finalBytes, finalChecksum);
+    var packageBytes = CreatePackage(manifest, files);
+    var packageChecksum = ComputeSha512(packageBytes);
+    return (packageBytes, packageChecksum);
 }
 
 static byte[] CreatePackage(UpdateManifest manifest, IReadOnlyList<UpdateFileContent> files)


### PR DESCRIPTION
## Summary
Fix a checksum mismatch that caused every update download to fail with `System.IO.InvalidDataException: 更新包校验失败`.

## Root Cause
`BuildPackageFile` in `TelegramSearchBot.UpdateBuilder` had a two-pass design:

1. **Pass 1**: Build a temp package with `manifest.Checksum = ""`, compute its SHA512 → `tempHash`
2. **Pass 2**: Embed `tempHash` into the manifest, rebuild the package → `finalBytes`
3. Store `tempHash` in the catalog entry, but write `finalBytes` to disk

Since `finalBytes` has a different manifest (containing the checksum), its actual SHA512 differs from `tempHash`. The catalog records the wrong checksum, and the client's `VerifyPackageChecksum` always rejects the downloaded package.

## Fix
Single-pass approach. The manifest's `Checksum` field is **never read** during update (`ExtractPackageToDirectory` skips `manifest.json`, and verification uses the catalog entry's `PackageChecksum`). So skip the two-pass embedding entirely and compute SHA512 from the actual package bytes that get written to disk.

## Changes
- `TelegramSearchBot.UpdateBuilder/Program.cs` `BuildPackageFile()`: removed the temp package / two-pass logic, now creates the package once and hashes the final bytes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal package build and verification process for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->