### PR TITLE
fix(update): embed asInvoker manifest in updater

### DIFF
--- a/TelegramSearchBot.Test/ModerUpdateIntegrationTests.cs
+++ b/TelegramSearchBot.Test/ModerUpdateIntegrationTests.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Xml.Linq;
 using Xunit;
 
 namespace TelegramSearchBot.Test {
@@ -133,6 +134,31 @@ namespace TelegramSearchBot.Test {
             } else {
                 Assert.Fail("Failed to start cargo build process - is cargo installed?");
             }
+        }
+
+        [Fact]
+        public void RustUpdater_WindowsManifest_DisablesInstallerElevationHeuristic() {
+            var updaterRoot = Path.Combine(SolutionRoot, "external", "moder-update", "src", "updater");
+            var buildScriptPath = Path.Combine(updaterRoot, "build.rs");
+            var manifestPath = Path.Combine(updaterRoot, "updater.exe.manifest");
+
+            Assert.True(File.Exists(buildScriptPath), "Rust updater should have a build script to embed its manifest.");
+            Assert.True(File.Exists(manifestPath), "Rust updater should ship an explicit Windows app manifest.");
+
+            var manifest = XDocument.Load(manifestPath);
+            XNamespace asmV3 = "urn:schemas-microsoft-com:asm.v3";
+            var requestedExecutionLevel = manifest
+                .Descendants(asmV3 + "requestedExecutionLevel")
+                .SingleOrDefault();
+
+            Assert.NotNull(requestedExecutionLevel);
+            Assert.Equal("asInvoker", requestedExecutionLevel.Attribute("level")?.Value);
+            Assert.Equal("false", requestedExecutionLevel.Attribute("uiAccess")?.Value);
+
+            var buildScript = File.ReadAllText(buildScriptPath);
+            Assert.Contains("/MANIFEST:EMBED", buildScript);
+            Assert.Contains("/MANIFESTINPUT:", buildScript);
+            Assert.Contains("updater.exe.manifest", buildScript);
         }
 
         [Fact]

--- a/external/moder-update/src/updater/build.rs
+++ b/external/moder-update/src/updater/build.rs
@@ -1,0 +1,25 @@
+use std::{env, path::Path};
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=updater.exe.manifest");
+
+    if env::var_os("CARGO_CFG_WINDOWS").is_none() {
+        return;
+    }
+
+    let target_env = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_env != "msvc" {
+        return;
+    }
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR")
+        .expect("Cargo should set CARGO_MANIFEST_DIR for build scripts.");
+    let manifest_path = Path::new(&manifest_dir).join("updater.exe.manifest");
+
+    println!("cargo:rustc-link-arg-bin=moder_update_updater=/MANIFEST:EMBED");
+    println!(
+        "cargo:rustc-link-arg-bin=moder_update_updater=/MANIFESTINPUT:{}",
+        manifest_path.display()
+    );
+}

--- a/external/moder-update/src/updater/updater.exe.manifest
+++ b/external/moder-update/src/updater/updater.exe.manifest
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <assemblyIdentity
+    name="Moder.Update.Updater"
+    processorArchitecture="*"
+    type="win32"
+    version="1.0.0.0" />
+  <description>Moder.Update updater</description>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false" />
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>


### PR DESCRIPTION
## Summary
- embed an explicit Windows `asInvoker` manifest into the Rust updater binary
- add a build script that passes the manifest to the MSVC linker during CI/release builds
- add regression coverage so the manifest and linker flags stay present

## Why
Windows can treat executables with names like `*_updater.exe` as installers when they do not carry an explicit manifest. The existing 570 client launches the downloaded updater with `CreateProcess` (`UseShellExecute=false`), so Windows returns Win32Exception 740 instead of showing UAC. Embedding `asInvoker` in the updater itself prevents the heuristic and fixes existing clients once they download the updated updater artifact.

## Validation
- `cargo build --manifest-path external/moder-update/src/updater/Cargo.toml --release`
- read the release updater RT_MANIFEST resource and verified `requestedExecutionLevel level="asInvoker"`
- `cargo test --manifest-path external/moder-update/src/updater/Cargo.toml`
- `dotnet test TelegramSearchBot.Test/TelegramSearchBot.Test.csproj --filter "FullyQualifiedName~ModerUpdateIntegrationTests|FullyQualifiedName~SelfUpdateBootstrapTests"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration test to validate Windows updater security configuration and manifest behavior.

* **Chores**
  * Configured Windows updater to run with standard user privileges instead of elevated permissions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModerRAS/TelegramSearchBot/pull/338)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->