### PR TITLE
fix(update): publish cumulative delta packages

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -18,6 +18,8 @@ env:
   B2_CLI_VERSION: '4.6.0'
   LEGACY_BRIDGE_VERSION: '2026.04.23.553'
   LEGACY_BRIDGE_MARKER: 'legacy-clickonce-bridge-version.txt'
+  CUMULATIVE_UPDATE_ANCHOR_VERSION: '2026.05.05.570'
+  UPDATE_BASE_URL: 'https://clickonce.miaostay.com/TelegramSearchBot'
 
 jobs:
   prepare:
@@ -226,30 +228,16 @@ jobs:
           /p:Version=$env:BUILD_VERSION `
           /p:PublishSingleFile=false `
           -o .\artifacts\standalone
-    - name: Fetch existing update catalog from B2
+    - name: Fetch existing update catalog from CDN
       shell: pwsh
-      env:
-        B2_BUCKET: ${{ secrets.B2_BUCKET }}
-        B2_APPKEY_ID: ${{ secrets.B2_APPKEY_ID }}
-        B2_APPKEY: ${{ secrets.B2_APPKEY }}
       run: |
-        if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
-          Write-Host "Python not available, skipping catalog fetch."
-          exit 0
-        }
-        pip install --quiet --cache-dir C:\pip-cache "b2==$env:B2_CLI_VERSION"
-        b2 account authorize $env:B2_APPKEY_ID $env:B2_APPKEY --quiet
-        if ($LASTEXITCODE -ne 0) {
-          Write-Host "B2 auth failed, will create fresh catalog."
-          exit 0
-        }
+        $catalogUri = "$($env:UPDATE_BASE_URL.TrimEnd('/'))/catalog.json"
         try {
-          b2 download-file-by-name $env:B2_BUCKET TelegramSearchBot/catalog.json .\artifacts\existing-catalog.json --quiet
-          Write-Host "Downloaded existing catalog.json for merge."
+          Invoke-WebRequest -UseBasicParsing -Uri $catalogUri -OutFile .\artifacts\existing-catalog.json
+          Write-Host "Downloaded existing catalog.json from CDN for merge."
         } catch {
-          Write-Host "No existing catalog found on B2, will create fresh catalog."
+          Write-Host "No existing catalog found on CDN, will create fresh catalog."
         }
-        b2 account clear
     - name: Fetch previous release standalone for step package comparison
       shell: pwsh
       env:
@@ -259,20 +247,154 @@ jobs:
         if ($prevRelease.Count -gt 0) {
           $prevTag = $prevRelease[0].tagName
           $prevVersion = $prevTag -replace '^v', ''
+          if ($prevVersion -eq "${{ needs.prepare.outputs.build-version }}") {
+            Write-Host "Previous release is the current build version; skipping step package generation."
+            exit 0
+          }
           Write-Host "Previous release: $prevTag (version: $prevVersion)"
           $prevArchive = ".\artifacts\prev-standalone.zip"
           gh release download $prevTag --repo ${{ github.repository }} --pattern "TelegramSearchBot-win-x64-full-*.zip" --dir artifacts\prev-release
           $zipFile = Get-ChildItem artifacts\prev-release -Filter "TelegramSearchBot-win-x64-full-*.zip" | Select-Object -First 1
           if ($zipFile) {
             Expand-Archive -Path $zipFile.FullName -DestinationPath .\artifacts\prev-standalone -Force
-            Write-Host "PREV_VERSION=$prevVersion" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-            Write-Host "PREV_STANDALONE_DIR=artifacts\prev-standalone" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+            Add-Content -Path $env:GITHUB_ENV -Value "PREV_VERSION=$prevVersion" -Encoding utf8
+            Add-Content -Path $env:GITHUB_ENV -Value "PREV_STANDALONE_DIR=artifacts\prev-standalone" -Encoding utf8
             Write-Host "Extracted previous standalone from $($zipFile.Name)."
           } else {
             Write-Host "No previous full zip found; step package will not be generated."
           }
         } else {
           Write-Host "No previous release found; this is the first release."
+        }
+    - name: Fetch cumulative update anchor standalone
+      shell: pwsh
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BUILD_VERSION: ${{ needs.prepare.outputs.build-version }}
+      run: |
+        $anchorVersion = $env:CUMULATIVE_UPDATE_ANCHOR_VERSION
+        if ([string]::IsNullOrWhiteSpace($anchorVersion)) {
+          Write-Host "No cumulative update anchor configured; cumulative delta package will not be generated."
+          exit 0
+        }
+        if ($anchorVersion -eq $env:BUILD_VERSION) {
+          Write-Host "Current build is the cumulative update anchor; cumulative delta package will not be generated."
+          exit 0
+        }
+
+        $anchorTag = "v$anchorVersion"
+        Write-Host "Cumulative update anchor: $anchorTag"
+        New-Item -ItemType Directory -Path artifacts\anchor-release -Force | Out-Null
+        gh release download $anchorTag --repo ${{ github.repository }} --pattern "TelegramSearchBot-win-x64-full-*.zip" --dir artifacts\anchor-release
+        if ($LASTEXITCODE -ne 0) {
+          Write-Host "Failed to download cumulative update anchor $anchorTag; cumulative delta package will not be generated."
+          exit 0
+        }
+
+        $zipFile = Get-ChildItem artifacts\anchor-release -Filter "TelegramSearchBot-win-x64-full-*.zip" | Select-Object -First 1
+        if ($zipFile) {
+          Expand-Archive -Path $zipFile.FullName -DestinationPath .\artifacts\anchor-standalone -Force
+          Add-Content -Path $env:GITHUB_ENV -Value "ANCHOR_VERSION=$anchorVersion" -Encoding utf8
+          Add-Content -Path $env:GITHUB_ENV -Value "ANCHOR_STANDALONE_DIR=artifacts\anchor-standalone" -Encoding utf8
+          Write-Host "Extracted cumulative update anchor from $($zipFile.Name)."
+        } else {
+          Write-Host "No anchor full zip found; cumulative delta package will not be generated."
+        }
+    - name: Fetch previous cumulative update package
+      shell: pwsh
+      run: |
+        if (-not (Test-Path '.\artifacts\existing-catalog.json')) {
+          Write-Host "No existing catalog found; base cumulative package will not be used."
+          exit 0
+        }
+        if (-not $env:PREV_VERSION) {
+          Write-Host "No previous version found; base cumulative package will not be used."
+          exit 0
+        }
+
+        $catalog = Get-Content '.\artifacts\existing-catalog.json' -Raw | ConvertFrom-Json
+        $baseEntry = @($catalog.Entries | Where-Object {
+          $_.TargetVersion -eq $env:PREV_VERSION `
+            -and $_.MinSourceVersion -eq $env:CUMULATIVE_UPDATE_ANCHOR_VERSION `
+            -and $_.IsCumulative
+        } | Sort-Object CompressedSize | Select-Object -First 1)
+
+        if ($baseEntry.Count -eq 0 -or -not $baseEntry[0].PackagePath) {
+          Write-Host "No previous cumulative package found in existing catalog."
+          exit 0
+        }
+
+        New-Item -ItemType Directory -Path artifacts\base-cumulative -Force | Out-Null
+        $basePackagePath = 'artifacts\base-cumulative\base-cumulative.zst'
+        $uri = "$($env:UPDATE_BASE_URL.TrimEnd('/'))/$($baseEntry[0].PackagePath.TrimStart('/'))"
+        try {
+          Invoke-WebRequest -UseBasicParsing -Uri $uri -OutFile $basePackagePath
+        } catch {
+          Write-Host "Failed to download base cumulative package from CDN; continuing without it."
+          exit 0
+        }
+        Add-Content -Path $env:GITHUB_ENV -Value "BASE_CUMULATIVE_PACKAGE=$basePackagePath" -Encoding utf8
+        Write-Host "Downloaded base cumulative package from CDN: $($baseEntry[0].PackagePath)"
+    - name: Fetch cumulative source packages from CDN
+      shell: pwsh
+      env:
+        BUILD_VERSION: ${{ needs.prepare.outputs.build-version }}
+      run: |
+        if ($env:BASE_CUMULATIVE_PACKAGE -and (Test-Path $env:BASE_CUMULATIVE_PACKAGE)) {
+          Write-Host "Base cumulative package is available; historical source packages are not needed."
+          exit 0
+        }
+        if (-not (Test-Path '.\artifacts\existing-catalog.json')) {
+          Write-Host "No existing catalog found; cumulative source packages will not be used."
+          exit 0
+        }
+
+        $anchor = [Version]$env:CUMULATIVE_UPDATE_ANCHOR_VERSION
+        $current = [Version]$env:BUILD_VERSION
+        $catalog = Get-Content '.\artifacts\existing-catalog.json' -Raw | ConvertFrom-Json
+        $entriesByVersion = @{}
+        foreach ($entry in $catalog.Entries) {
+          if (-not $entry.PackagePath -or $entry.PackagePath -notlike '*-full.zst') {
+            continue
+          }
+
+          try {
+            $target = [Version]$entry.TargetVersion
+          } catch {
+            continue
+          }
+
+          if ($target -lt $anchor -or $target -ge $current) {
+            continue
+          }
+
+          $key = $entry.TargetVersion
+          if (-not $entriesByVersion.ContainsKey($key) -or $entry.CompressedSize -lt $entriesByVersion[$key].CompressedSize) {
+            $entriesByVersion[$key] = $entry
+          }
+        }
+
+        if ($entriesByVersion.Count -eq 0) {
+          Write-Host "No cumulative source full packages found in existing catalog."
+          exit 0
+        }
+
+        $sourcePackageDir = 'artifacts\cumulative-source-packages'
+        New-Item -ItemType Directory -Path $sourcePackageDir -Force | Out-Null
+        foreach ($key in ($entriesByVersion.Keys | Sort-Object { [Version]$_ })) {
+          $entry = $entriesByVersion[$key]
+          $packagePath = Join-Path $sourcePackageDir ("source-$($key.Replace('.', '-')).zst")
+          $uri = "$($env:UPDATE_BASE_URL.TrimEnd('/'))/$($entry.PackagePath.TrimStart('/'))"
+          try {
+            Invoke-WebRequest -UseBasicParsing -Uri $uri -OutFile $packagePath
+            Write-Host "Downloaded cumulative source package from CDN: $($entry.PackagePath)"
+          } catch {
+            Write-Host "Failed to download cumulative source package from CDN: $($entry.PackagePath)"
+          }
+        }
+
+        if ((Get-ChildItem $sourcePackageDir -Filter '*.zst' -File | Measure-Object).Count -gt 0) {
+          Add-Content -Path $env:GITHUB_ENV -Value "CUMULATIVE_SOURCE_PACKAGE_DIR=$sourcePackageDir" -Encoding utf8
         }
     - name: Build Moder.Update feed
       shell: pwsh
@@ -292,6 +414,16 @@ jobs:
         if ($env:PREV_VERSION -and (Test-Path $env:PREV_STANDALONE_DIR)) {
           $builderArgs += @('--prev-source-dir', $env:PREV_STANDALONE_DIR, '--prev-version', $env:PREV_VERSION)
           Write-Host "Passing previous version $env:PREV_VERSION for step package generation."
+        }
+        if ($env:ANCHOR_VERSION -and (Test-Path $env:ANCHOR_STANDALONE_DIR)) {
+          $builderArgs += @('--anchor-source-dir', $env:ANCHOR_STANDALONE_DIR, '--anchor-version', $env:ANCHOR_VERSION)
+          if ($env:BASE_CUMULATIVE_PACKAGE -and (Test-Path $env:BASE_CUMULATIVE_PACKAGE)) {
+            $builderArgs += @('--base-cumulative-package', $env:BASE_CUMULATIVE_PACKAGE)
+          }
+          if ($env:CUMULATIVE_SOURCE_PACKAGE_DIR -and (Test-Path $env:CUMULATIVE_SOURCE_PACKAGE_DIR)) {
+            $builderArgs += @('--cumulative-source-package-dir', $env:CUMULATIVE_SOURCE_PACKAGE_DIR)
+          }
+          Write-Host "Passing cumulative update anchor $env:ANCHOR_VERSION."
         }
         dotnet run --project .\TelegramSearchBot.UpdateBuilder\TelegramSearchBot.UpdateBuilder.csproj `
           -c Release `

--- a/TelegramSearchBot.Test/ModerUpdateIntegrationTests.cs
+++ b/TelegramSearchBot.Test/ModerUpdateIntegrationTests.cs
@@ -331,6 +331,39 @@ namespace TelegramSearchBot.Test {
                 "CI workflow should define 'moder-update-updater' artifact");
         }
 
+        [Fact]
+        public void CI_UpdateFeed_GeneratesCumulativeDeltaFromAnchor() {
+            var pushYmlPath = Path.Combine(SolutionRoot, ".github", "workflows", "push.yml");
+            Assert.True(File.Exists(pushYmlPath), "push.yml workflow file should exist");
+
+            var pushYmlContent = File.ReadAllText(pushYmlPath);
+
+            Assert.Contains("CUMULATIVE_UPDATE_ANCHOR_VERSION", pushYmlContent);
+            Assert.Contains("2026.05.05.570", pushYmlContent);
+            Assert.Contains("UPDATE_BASE_URL", pushYmlContent);
+            Assert.Contains("Fetch existing update catalog from CDN", pushYmlContent);
+            Assert.Contains("Fetch cumulative update anchor standalone", pushYmlContent);
+            Assert.Contains("Fetch previous cumulative update package", pushYmlContent);
+            Assert.Contains("Fetch cumulative source packages from CDN", pushYmlContent);
+            Assert.Contains("ANCHOR_VERSION=", pushYmlContent);
+            Assert.Contains("ANCHOR_STANDALONE_DIR=", pushYmlContent);
+            Assert.Contains("BASE_CUMULATIVE_PACKAGE=", pushYmlContent);
+            Assert.Contains("CUMULATIVE_SOURCE_PACKAGE_DIR=", pushYmlContent);
+            Assert.Contains("'--anchor-source-dir'", pushYmlContent);
+            Assert.Contains("'--anchor-version'", pushYmlContent);
+            Assert.Contains("'--base-cumulative-package'", pushYmlContent);
+            Assert.Contains("'--cumulative-source-package-dir'", pushYmlContent);
+            Assert.Contains("Downloaded existing catalog.json from CDN", pushYmlContent);
+            Assert.Contains("Downloaded base cumulative package from CDN", pushYmlContent);
+            Assert.Contains("Downloaded cumulative source package from CDN", pushYmlContent);
+            Assert.Contains("historical source packages are not needed", pushYmlContent);
+            Assert.Contains("Passing cumulative update anchor", pushYmlContent);
+            Assert.DoesNotContain("Fetch existing update catalog from B2", pushYmlContent);
+            Assert.DoesNotContain("b2 download-file-by-name", pushYmlContent);
+            Assert.DoesNotContain("Write-Host \"PREV_VERSION=$prevVersion\" | Out-File", pushYmlContent);
+            Assert.DoesNotContain("Write-Host \"PREV_STANDALONE_DIR=artifacts\\prev-standalone\" | Out-File", pushYmlContent);
+        }
+
         private static IEnumerable<string> GetCsFilesRecursively(string root) {
             var files = new List<string>();
             try {

--- a/TelegramSearchBot.Test/Service/Update/SelfUpdateBootstrapTests.cs
+++ b/TelegramSearchBot.Test/Service/Update/SelfUpdateBootstrapTests.cs
@@ -311,7 +311,8 @@ public class SelfUpdateBootstrapTests
         string? maxSourceVersion = null,
         bool isCumulative = false,
         bool isAnchor = false,
-        int chainDepth = 0)
+        int chainDepth = 0,
+        long compressedSize = 1024)
     {
         return new UpdateCatalogEntry
         {
@@ -324,7 +325,7 @@ public class SelfUpdateBootstrapTests
             ChainDepth = chainDepth,
             PackageChecksum = "a1b2c3d4e5f6",
             FileCount = 10,
-            CompressedSize = 1024,
+            CompressedSize = compressedSize,
             UncompressedSize = 2048,
         };
     }
@@ -432,6 +433,62 @@ public class SelfUpdateBootstrapTests
         Assert.True(result[0].IsCumulative);
         Assert.Equal("1.8.0", result[0].TargetVersion);
         Assert.Equal("2.0.0", result[1].TargetVersion);
+    }
+
+    [Fact]
+    public void PlanUpdatePath_PrefersCumulativeDeltaOverFullFallback()
+    {
+        var entries = new List<UpdateCatalogEntry>
+        {
+            CreateEntry(
+                "2026.05.10.572",
+                "2026.04.23.553",
+                isCumulative: true,
+                isAnchor: true,
+                compressedSize: 568_000_000),
+            CreateEntry(
+                "2026.05.10.572",
+                "2026.04.25.561",
+                isCumulative: true,
+                isAnchor: true,
+                compressedSize: 12_000_000)
+        };
+        var current = new Version(2026, 05, 05, 570);
+        var target = new Version(2026, 05, 10, 572);
+
+        var result = InvokePrivateStatic<List<UpdateCatalogEntry>>(
+            "PlanUpdatePath", entries, current, target)!;
+
+        Assert.Single(result);
+        Assert.Equal("2026.04.25.561", result[0].MinSourceVersion);
+    }
+
+    [Fact]
+    public void PlanUpdatePath_UsesFullFallbackWhenCurrentIsBeforeCumulativeAnchor()
+    {
+        var entries = new List<UpdateCatalogEntry>
+        {
+            CreateEntry(
+                "2026.05.10.572",
+                "2026.04.23.553",
+                isCumulative: true,
+                isAnchor: true,
+                compressedSize: 568_000_000),
+            CreateEntry(
+                "2026.05.10.572",
+                "2026.04.25.561",
+                isCumulative: true,
+                isAnchor: true,
+                compressedSize: 12_000_000)
+        };
+        var current = new Version(2026, 04, 23, 553);
+        var target = new Version(2026, 05, 10, 572);
+
+        var result = InvokePrivateStatic<List<UpdateCatalogEntry>>(
+            "PlanUpdatePath", entries, current, target)!;
+
+        Assert.Single(result);
+        Assert.Equal("2026.04.23.553", result[0].MinSourceVersion);
     }
 
     // ── CanApplyEntry ──────────────────────────────────────────────

--- a/TelegramSearchBot.UpdateBuilder/Program.cs
+++ b/TelegramSearchBot.UpdateBuilder/Program.cs
@@ -57,9 +57,10 @@ if (!string.IsNullOrWhiteSpace(arguments.ExistingCatalog) && File.Exists(argumen
 
 catalogEntries.RemoveAll(e => string.Equals(e.TargetVersion, currentVersion, StringComparison.OrdinalIgnoreCase));
 
+List<UpdateFileContent>? prevFiles = null;
 if (!string.IsNullOrWhiteSpace(arguments.PrevSourceDir) && Directory.Exists(arguments.PrevSourceDir))
 {
-    var prevFiles = LoadFiles(arguments.PrevSourceDir);
+    prevFiles = LoadFiles(arguments.PrevSourceDir);
     var prevVersion = arguments.PrevVersion!;
 
     var changedFiles = ComputeChangedFiles(prevFiles, currentFiles);
@@ -106,8 +107,30 @@ if (!string.IsNullOrWhiteSpace(arguments.AnchorVersion) && !string.IsNullOrWhite
     var anchorDir = Path.GetFullPath(arguments.AnchorSourceDir);
     if (Directory.Exists(anchorDir))
     {
+        var cumulativeFileSets = new List<IEnumerable<UpdateFileContent>>();
+        if (!string.IsNullOrWhiteSpace(arguments.BaseCumulativePackage)
+            && File.Exists(arguments.BaseCumulativePackage))
+        {
+            var baseCumulativeFiles = LoadPackageFiles(arguments.BaseCumulativePackage);
+            cumulativeFileSets.Add(baseCumulativeFiles);
+            Console.WriteLine(
+                $"Loaded base cumulative package: {arguments.BaseCumulativePackage} ({baseCumulativeFiles.Count} files)");
+        }
+
+        foreach (var sourceManifest in LoadCumulativeSourceManifests(arguments.CumulativeSourcePackageDir))
+        {
+            cumulativeFileSets.Add(ComputeChangedFilesFromManifest(sourceManifest, currentFiles));
+        }
+
         var anchorFiles = LoadFiles(anchorDir);
-        var changedFromAnchor = ComputeChangedFiles(anchorFiles, currentFiles);
+        cumulativeFileSets.Add(ComputeChangedFiles(anchorFiles, currentFiles));
+
+        if (prevFiles is not null)
+        {
+            cumulativeFileSets.Add(ComputeChangedFiles(prevFiles, currentFiles));
+        }
+
+        var changedFromAnchor = MergeChangedFiles(cumulativeFileSets.ToArray());
         if (changedFromAnchor.Count > 0)
         {
             var cumulativePath =
@@ -136,6 +159,10 @@ if (!string.IsNullOrWhiteSpace(arguments.AnchorVersion) && !string.IsNullOrWhite
 
             Console.WriteLine(
                 $"Cumulative package written: {cumulativePath} ({changedFromAnchor.Count} files from anchor {arguments.AnchorVersion}, {cumBytes.LongLength} bytes compressed)");
+        }
+        else
+        {
+            Console.WriteLine("No changed files detected from anchor; skipping cumulative package generation.");
         }
     }
     else
@@ -215,8 +242,9 @@ static List<UpdateCatalogEntry> PruneCatalogEntries(
 
     var rest = entries.Where(e =>
             !string.Equals(e.TargetVersion, latestVersion, StringComparison.OrdinalIgnoreCase))
-        .OrderByDescending(e => e.IsCumulative)
-        .ThenByDescending(e => Version.TryParse(e.TargetVersion, out var v) ? v : new Version(0, 0))
+        .OrderByDescending(e => Version.TryParse(e.TargetVersion, out var v) ? v : new Version(0, 0))
+        .ThenBy(e => e.IsCumulative)
+        .ThenBy(e => e.ChainDepth)
         .ToList();
 
     var result = latest;
@@ -307,6 +335,103 @@ static List<UpdateFileContent> LoadFiles(string sourceDirectory)
         .ToList();
 }
 
+static List<UpdateFileContent> LoadPackageFiles(string packagePath)
+{
+    using var packageStream = File.OpenRead(packagePath);
+    if (!ValidatePackageMagic(packageStream))
+    {
+        throw new InvalidDataException($"Invalid Moder.Update package magic header: {packagePath}");
+    }
+
+    var files = new List<UpdateFileContent>();
+    using var decompressed = new DecompressionStream(packageStream, leaveOpen: false);
+    using var tarReader = new TarReader(decompressed, leaveOpen: true);
+    while (tarReader.GetNextEntry() is { } entry)
+    {
+        if (string.Equals(entry.Name, "manifest.json", StringComparison.OrdinalIgnoreCase))
+        {
+            continue;
+        }
+
+        if (entry.EntryType != TarEntryType.RegularFile
+            && entry.EntryType != TarEntryType.V7RegularFile
+            || entry.DataStream is null)
+        {
+            continue;
+        }
+
+        using var fileContent = new MemoryStream();
+        entry.DataStream.CopyTo(fileContent);
+        files.Add(new UpdateFileContent(entry.Name.Replace('/', Path.DirectorySeparatorChar), fileContent.ToArray()));
+    }
+
+    return files
+        .OrderBy(file => file.RelativePath, StringComparer.OrdinalIgnoreCase)
+        .ToList();
+}
+
+static bool ValidatePackageMagic(Stream packageStream)
+{
+    Span<byte> buffer = stackalloc byte[4];
+    var bytesRead = packageStream.Read(buffer);
+    return bytesRead == 4
+        && buffer[0] == 0x4D
+        && buffer[1] == 0x55
+        && buffer[2] == 0x50
+        && buffer[3] == 0x00;
+}
+
+static List<List<UpdateFileFingerprint>> LoadCumulativeSourceManifests(string? packageDirectory)
+{
+    if (string.IsNullOrWhiteSpace(packageDirectory) || !Directory.Exists(packageDirectory))
+    {
+        return [];
+    }
+
+    var manifests = new List<List<UpdateFileFingerprint>>();
+    foreach (var packagePath in Directory.GetFiles(packageDirectory, "*.zst", SearchOption.TopDirectoryOnly))
+    {
+        var files = LoadPackageManifestFiles(packagePath);
+        manifests.Add(files);
+        Console.WriteLine($"Loaded cumulative source package manifest: {packagePath} ({files.Count} files)");
+    }
+
+    return manifests;
+}
+
+static List<UpdateFileFingerprint> LoadPackageManifestFiles(string packagePath)
+{
+    using var packageStream = File.OpenRead(packagePath);
+    if (!ValidatePackageMagic(packageStream))
+    {
+        throw new InvalidDataException($"Invalid Moder.Update package magic header: {packagePath}");
+    }
+
+    using var decompressed = new DecompressionStream(packageStream, leaveOpen: false);
+    using var tarReader = new TarReader(decompressed, leaveOpen: true);
+    while (tarReader.GetNextEntry() is { } entry)
+    {
+        if (!string.Equals(entry.Name, "manifest.json", StringComparison.OrdinalIgnoreCase))
+        {
+            continue;
+        }
+
+        if (entry.DataStream is null)
+        {
+            throw new InvalidDataException($"Package manifest has no data stream: {packagePath}");
+        }
+
+        var manifest = JsonSerializer.Deserialize<UpdateManifest>(entry.DataStream, JsonOptions)
+            ?? throw new InvalidDataException($"Failed to parse package manifest: {packagePath}");
+        return manifest.Files
+            .Select(file => new UpdateFileFingerprint(file.RelativePath, file.NewChecksum))
+            .OrderBy(file => file.RelativePath, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    throw new InvalidDataException($"Package manifest not found: {packagePath}");
+}
+
 static List<UpdateFileContent> ComputeChangedFiles(
     List<UpdateFileContent> prevFiles,
     List<UpdateFileContent> currentFiles)
@@ -328,6 +453,46 @@ static List<UpdateFileContent> ComputeChangedFiles(
     }
 
     return changed;
+}
+
+static List<UpdateFileContent> ComputeChangedFilesFromManifest(
+    List<UpdateFileFingerprint> sourceFiles,
+    List<UpdateFileContent> currentFiles)
+{
+    var sourceMap = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+    foreach (var file in sourceFiles)
+    {
+        sourceMap[file.RelativePath] = file.Checksum;
+    }
+
+    var changed = new List<UpdateFileContent>();
+    foreach (var file in currentFiles)
+    {
+        var currentHash = ComputeSha512(file.Content);
+        if (!sourceMap.TryGetValue(file.RelativePath, out var sourceHash)
+            || !sourceHash.Equals(currentHash, StringComparison.OrdinalIgnoreCase))
+        {
+            changed.Add(file);
+        }
+    }
+
+    return changed;
+}
+
+static List<UpdateFileContent> MergeChangedFiles(params IEnumerable<UpdateFileContent>[] fileSets)
+{
+    var merged = new Dictionary<string, UpdateFileContent>(StringComparer.OrdinalIgnoreCase);
+    foreach (var fileSet in fileSets)
+    {
+        foreach (var file in fileSet)
+        {
+            merged[file.RelativePath] = file;
+        }
+    }
+
+    return merged.Values
+        .OrderBy(file => file.RelativePath, StringComparer.OrdinalIgnoreCase)
+        .ToList();
 }
 
 static string ComputeSha512(byte[] data)
@@ -363,6 +528,8 @@ internal sealed class BuilderArguments
     public string? ExistingCatalog { get; private init; }
     public string? AnchorVersion { get; private init; }
     public string? AnchorSourceDir { get; private init; }
+    public string? BaseCumulativePackage { get; private init; }
+    public string? CumulativeSourcePackageDir { get; private init; }
 
     public bool IsValid =>
         !string.IsNullOrWhiteSpace(SourceDirectory)
@@ -393,6 +560,8 @@ internal sealed class BuilderArguments
         values.TryGetValue("--existing-catalog", out var existingCatalog);
         values.TryGetValue("--anchor-version", out var anchorVersion);
         values.TryGetValue("--anchor-source-dir", out var anchorSourceDir);
+        values.TryGetValue("--base-cumulative-package", out var baseCumulativePackage);
+        values.TryGetValue("--cumulative-source-package-dir", out var cumulativeSourcePackageDir);
 
         return new BuilderArguments
         {
@@ -405,7 +574,9 @@ internal sealed class BuilderArguments
             PrevVersion = prevVersion,
             ExistingCatalog = existingCatalog,
             AnchorVersion = anchorVersion,
-            AnchorSourceDir = anchorSourceDir
+            AnchorSourceDir = anchorSourceDir,
+            BaseCumulativePackage = baseCumulativePackage,
+            CumulativeSourcePackageDir = cumulativeSourcePackageDir
         };
     }
 
@@ -413,11 +584,13 @@ internal sealed class BuilderArguments
     {
         Console.WriteLine("Usage:");
         Console.WriteLine(
-            "  TelegramSearchBot.UpdateBuilder --source-dir <dir> --output-dir <dir> --target-version <version> --min-source-version <version> [--prev-source-dir <dir> --prev-version <version>] [--existing-catalog <path>] [--anchor-version <version> --anchor-source-dir <dir>]");
+            "  TelegramSearchBot.UpdateBuilder --source-dir <dir> --output-dir <dir> --target-version <version> --min-source-version <version> [--prev-source-dir <dir> --prev-version <version>] [--existing-catalog <path>] [--anchor-version <version> --anchor-source-dir <dir>] [--base-cumulative-package <path>] [--cumulative-source-package-dir <dir>]");
     }
 }
 
 internal sealed record UpdateFileContent(string RelativePath, byte[] Content);
+
+internal sealed record UpdateFileFingerprint(string RelativePath, string Checksum);
 
 internal static partial class Program
 {

--- a/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.Windows.cs
+++ b/TelegramSearchBot/Service/Update/SelfUpdateBootstrap.Windows.cs
@@ -124,50 +124,118 @@ public static partial class SelfUpdateBootstrap
         Version currentVersion,
         Version targetVersion)
     {
-        var remaining = new HashSet<UpdateCatalogEntry>(entries);
-        var path = new List<UpdateCatalogEntry>();
-        var versionCursor = currentVersion;
+        var candidates = entries
+            .Select(TryCreateUpdateCandidate)
+            .Where(candidate => candidate is not null
+                && candidate.TargetVersion <= targetVersion
+                && candidate.TargetVersion > currentVersion)
+            .Cast<UpdateCandidate>()
+            .ToList();
+        var bestPlans = new Dictionary<Version, UpdatePlanNode> {
+            [currentVersion] = new() {
+                Cost = 0,
+                PackageCount = 0
+            }
+        };
+        var queue = new PriorityQueue<Version, UpdatePlanPriority>();
+        queue.Enqueue(currentVersion, new UpdatePlanPriority(0, 0));
 
-        while (versionCursor < targetVersion) {
-            var candidates = remaining
-                .Where(e => CanApplyEntry(versionCursor, e))
-                .ToList();
-
-            if (candidates.Count == 0) {
-                return [];
+        while (queue.TryDequeue(out var versionCursor, out var priority)) {
+            if (!bestPlans.TryGetValue(versionCursor, out var currentPlan)
+                || currentPlan.Cost != priority.Cost
+                || currentPlan.PackageCount != priority.PackageCount) {
+                continue;
             }
 
-            UpdateCatalogEntry bestPick;
-            var directToTarget = candidates.FirstOrDefault(e =>
-                Version.TryParse(e.TargetVersion, out var tv) && tv >= targetVersion);
-
-            if (directToTarget is not null) {
-                bestPick = directToTarget;
-            } else {
-                var cumulative = candidates
-                    .Where(e => e.IsCumulative)
-                    .OrderByDescending(e => Version.TryParse(e.TargetVersion, out var v) ? v : new Version(0, 0))
-                    .FirstOrDefault();
-
-                bestPick = cumulative ?? candidates
-                    .OrderByDescending(e => Version.TryParse(e.TargetVersion, out var v) ? v : new Version(0, 0))
-                    .First();
+            if (versionCursor == targetVersion) {
+                break;
             }
 
-            path.Add(bestPick);
-            remaining.Remove(bestPick);
+            foreach (var candidate in candidates.Where(candidate => candidate.AppliesTo(versionCursor))) {
+                var packageCost = GetPackageDownloadCost(candidate.Entry);
+                if (currentPlan.Cost > long.MaxValue - packageCost) {
+                    continue;
+                }
 
-            if (!Version.TryParse(bestPick.TargetVersion, out var newCursor)) {
-                return [];
+                var nextCost = currentPlan.Cost + packageCost;
+                var nextPackageCount = currentPlan.PackageCount + 1;
+                if (bestPlans.TryGetValue(candidate.TargetVersion, out var existingPlan)
+                    && !IsBetterPlan(nextCost, nextPackageCount, existingPlan)) {
+                    continue;
+                }
+
+                bestPlans[candidate.TargetVersion] = new UpdatePlanNode {
+                    PreviousVersion = versionCursor,
+                    Entry = candidate.Entry,
+                    Cost = nextCost,
+                    PackageCount = nextPackageCount
+                };
+                queue.Enqueue(candidate.TargetVersion, new UpdatePlanPriority(nextCost, nextPackageCount));
             }
-
-            if (newCursor <= versionCursor) {
-                return [];
-            }
-
-            versionCursor = newCursor;
         }
 
+        if (!bestPlans.ContainsKey(targetVersion)) {
+            return [];
+        }
+
+        return BuildUpdatePath(bestPlans, currentVersion, targetVersion);
+    }
+
+    private static UpdateCandidate? TryCreateUpdateCandidate(UpdateCatalogEntry entry)
+    {
+        if (!Version.TryParse(entry.MinSourceVersion, out var minVersion)
+            || !Version.TryParse(entry.TargetVersion, out var targetVersion)) {
+            return null;
+        }
+
+        Version? maxVersion = null;
+        if (!string.IsNullOrWhiteSpace(entry.MaxSourceVersion)
+            && !Version.TryParse(entry.MaxSourceVersion, out maxVersion)) {
+            return null;
+        }
+
+        return new UpdateCandidate(entry, minVersion, maxVersion, targetVersion);
+    }
+
+    private static long GetPackageDownloadCost(UpdateCatalogEntry entry)
+    {
+        if (entry.CompressedSize > 0) {
+            return entry.CompressedSize;
+        }
+
+        if (entry.UncompressedSize > 0) {
+            return entry.UncompressedSize;
+        }
+
+        return entry.IsCumulative ? 2L : 1L;
+    }
+
+    private static bool IsBetterPlan(long cost, int packageCount, UpdatePlanNode existingPlan)
+    {
+        return cost < existingPlan.Cost
+            || cost == existingPlan.Cost && packageCount < existingPlan.PackageCount;
+    }
+
+    private static List<UpdateCatalogEntry> BuildUpdatePath(
+        Dictionary<Version, UpdatePlanNode> bestPlans,
+        Version currentVersion,
+        Version targetVersion)
+    {
+        var path = new List<UpdateCatalogEntry>();
+        var versionCursor = targetVersion;
+
+        while (versionCursor != currentVersion) {
+            if (!bestPlans.TryGetValue(versionCursor, out var node)
+                || node.PreviousVersion is null
+                || node.Entry is null) {
+                return [];
+            }
+
+            path.Add(node.Entry);
+            versionCursor = node.PreviousVersion;
+        }
+
+        path.Reverse();
         return path;
     }
 
@@ -482,6 +550,42 @@ public static partial class SelfUpdateBootstrap
         public required string TargetPath { get; init; }
         public required string StagingDir { get; init; }
         public required string BackupDir { get; init; }
+    }
+
+    private sealed record UpdateCandidate(
+        UpdateCatalogEntry Entry,
+        Version MinVersion,
+        Version? MaxVersion,
+        Version TargetVersion)
+    {
+        public bool AppliesTo(Version currentVersion)
+        {
+            return currentVersion >= MinVersion
+                && (MaxVersion is null || currentVersion <= MaxVersion)
+                && currentVersion < TargetVersion;
+        }
+    }
+
+    private sealed class UpdatePlanNode
+    {
+        public Version? PreviousVersion { get; init; }
+        public UpdateCatalogEntry? Entry { get; init; }
+        public long Cost { get; init; }
+        public int PackageCount { get; init; }
+    }
+
+    private readonly record struct UpdatePlanPriority(long Cost, int PackageCount)
+        : IComparable<UpdatePlanPriority>
+    {
+        public int CompareTo(UpdatePlanPriority other)
+        {
+            var costComparison = Cost.CompareTo(other.Cost);
+            if (costComparison != 0) {
+                return costComparison;
+            }
+
+            return PackageCount.CompareTo(other.PackageCount);
+        }
     }
 
     private sealed class UpdateCheckResult


### PR DESCRIPTION
## Summary
- Generate cumulative delta update packages from a fixed post-bridge anchor (`2026.05.05.570`) plus rolling base cumulative packages.
- Fix the push workflow so previous standalone env vars are actually exported, and fetch existing catalog/update source packages through the Cloudflare CDN instead of Backblaze/B2 download APIs during build.
- Make the Windows updater choose the lowest download-cost update path so applicable cumulative/step packages win over full fallback packages.

## Validation
- `dotnet build TelegramSearchBot.UpdateBuilder/TelegramSearchBot.UpdateBuilder.csproj --configuration Release`
- `dotnet test TelegramSearchBot.Test/TelegramSearchBot.Test.csproj --filter "FullyQualifiedName~SelfUpdateBootstrapTests|FullyQualifiedName~ModerUpdateIntegrationTests.CI_UpdateFeed_GeneratesCumulativeDeltaFromAnchor"`
- Local UpdateBuilder simulation verified step, cumulative, and full package generation, including cumulative source manifest coverage.