### PR TITLE
test(update): require cumulative feed entries

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -287,8 +287,7 @@ jobs:
         New-Item -ItemType Directory -Path artifacts\anchor-release -Force | Out-Null
         gh release download $anchorTag --repo ${{ github.repository }} --pattern "TelegramSearchBot-win-x64-full-*.zip" --dir artifacts\anchor-release
         if ($LASTEXITCODE -ne 0) {
-          Write-Host "Failed to download cumulative update anchor $anchorTag; cumulative delta package will not be generated."
-          exit 0
+          throw "Failed to download cumulative update anchor $anchorTag; refusing to publish a full-only update feed."
         }
 
         $zipFile = Get-ChildItem artifacts\anchor-release -Filter "TelegramSearchBot-win-x64-full-*.zip" | Select-Object -First 1
@@ -298,7 +297,7 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "ANCHOR_STANDALONE_DIR=artifacts\anchor-standalone" -Encoding utf8
           Write-Host "Extracted cumulative update anchor from $($zipFile.Name)."
         } else {
-          Write-Host "No anchor full zip found; cumulative delta package will not be generated."
+          throw "No anchor full zip found; refusing to publish a full-only update feed."
         }
     - name: Fetch previous cumulative update package
       shell: pwsh
@@ -435,6 +434,25 @@ jobs:
         $catalog = Get-Content $catalogPath -Raw | ConvertFrom-Json
         $catalog | Add-Member -NotePropertyName UpdaterChecksum -NotePropertyValue ((Get-FileHash .\artifacts\update-feed\moder_update_updater.exe -Algorithm SHA512).Hash.ToLower()) -Force
         $catalog | ConvertTo-Json -Depth 10 | Set-Content $catalogPath -Encoding utf8
+        $catalog = Get-Content $catalogPath -Raw | ConvertFrom-Json
+        $entryTable = $catalog.Entries |
+          Sort-Object TargetVersion, PackagePath |
+          Select-Object TargetVersion, MinSourceVersion, MaxSourceVersion, IsCumulative, FileCount, CompressedSize, PackagePath |
+          Format-Table -AutoSize |
+          Out-String
+        Write-Host "Update feed catalog entries:"
+        Write-Host $entryTable
+        if ($env:ANCHOR_VERSION) {
+          $latestCumulativeEntries = @($catalog.Entries | Where-Object {
+            $_.TargetVersion -eq $env:BUILD_VERSION `
+              -and $_.MinSourceVersion -eq $env:ANCHOR_VERSION `
+              -and $_.IsCumulative `
+              -and $_.PackagePath -like '*-cumulative.zst'
+          })
+          if ($latestCumulativeEntries.Count -eq 0) {
+            throw "Cumulative update package missing for $env:ANCHOR_VERSION to $env:BUILD_VERSION."
+          }
+        }
     - name: Package full release asset
       shell: pwsh
       env:

--- a/TelegramSearchBot.Test/ModerUpdateIntegrationTests.cs
+++ b/TelegramSearchBot.Test/ModerUpdateIntegrationTests.cs
@@ -358,6 +358,10 @@ namespace TelegramSearchBot.Test {
             Assert.Contains("Downloaded cumulative source package from CDN", pushYmlContent);
             Assert.Contains("historical source packages are not needed", pushYmlContent);
             Assert.Contains("Passing cumulative update anchor", pushYmlContent);
+            Assert.Contains("Update feed catalog entries", pushYmlContent);
+            Assert.Contains("Cumulative update package missing", pushYmlContent);
+            Assert.Contains("Failed to download cumulative update anchor", pushYmlContent);
+            Assert.Contains("refusing to publish a full-only update feed", pushYmlContent);
             Assert.DoesNotContain("Fetch existing update catalog from B2", pushYmlContent);
             Assert.DoesNotContain("b2 download-file-by-name", pushYmlContent);
             Assert.DoesNotContain("Write-Host \"PREV_VERSION=$prevVersion\" | Out-File", pushYmlContent);


### PR DESCRIPTION
## Summary
- fail the publish workflow if the cumulative anchor download fails or no anchor full zip is found
- print the generated update-feed catalog entries in CI so delta/cumulative/full packages are visible in logs
- assert the workflow requires a cumulative catalog entry from the configured anchor to the current build

## Notes
GitHub Release assets still intentionally publish only the standalone full zip. Auto-update packages are uploaded through the update feed/CDN path; this PR makes CI fail if that feed does not contain the cumulative package.

## Test
- dotnet test TelegramSearchBot.Test\TelegramSearchBot.Test.csproj --filter "FullyQualifiedName~ModerUpdateIntegrationTests.CI_UpdateFeed_GeneratesCumulativeDeltaFromAnchor" --no-restore