### PR TITLE
fix: route agent tools through main-process proxy

### DIFF
--- a/TelegramSearchBot.LLM.Test/Service/AI/LLM/AgentProcessToolRegistrationTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/AI/LLM/AgentProcessToolRegistrationTests.cs
@@ -1,0 +1,25 @@
+using System.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using TelegramSearchBot.LLMAgent;
+using TelegramSearchBot.Service.AI.LLM;
+using Xunit;
+
+namespace TelegramSearchBot.LLM.Test.Service.AI.LLM {
+    public class AgentProcessToolRegistrationTests {
+        [Fact]
+        public void BuildServices_RegistersResponsesApiExecutor() {
+            using var provider = BuildAgentServices();
+
+            Assert.NotNull(provider.GetService<OpenAIResponsesService>());
+        }
+
+        private static ServiceProvider BuildAgentServices() {
+            var method = typeof(LLMAgentProgram).GetMethod("BuildServices", BindingFlags.NonPublic | BindingFlags.Static);
+            Assert.NotNull(method);
+
+            var provider = method!.Invoke(null, new object[] { 43210 }) as ServiceProvider;
+            Assert.NotNull(provider);
+            return provider!;
+        }
+    }
+}

--- a/TelegramSearchBot.LLM.Test/Service/AI/LLM/McpToolHelperProxyTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/AI/LLM/McpToolHelperProxyTests.cs
@@ -1,0 +1,50 @@
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Model.AI;
+using TelegramSearchBot.Service.AI.LLM;
+using Xunit;
+
+namespace TelegramSearchBot.LLM.Test.Service.AI.LLM {
+    public class McpToolHelperProxyTests {
+        [Fact]
+        public async Task ExecuteRegisteredToolAsync_ProxyTool_ForwardsToolContextMetadata() {
+            var toolName = $"proxy_context_test_{Guid.NewGuid():N}";
+            Dictionary<string, string>? forwardedArguments = null;
+
+            McpToolHelper.RegisterProxyTools([
+                new ProxyToolDefinition {
+                    Name = toolName,
+                    Description = "Test proxy tool.",
+                    Parameters = [
+                        new ProxyToolParameter {
+                            Name = "query",
+                            Type = "string",
+                            Description = "Query text.",
+                            Required = true
+                        }
+                    ]
+                }
+            ], (_, arguments) => {
+                forwardedArguments = new Dictionary<string, string>(arguments, StringComparer.OrdinalIgnoreCase);
+                return Task.FromResult("ok");
+            });
+
+            var result = await McpToolHelper.ExecuteRegisteredToolAsync(
+                toolName,
+                new Dictionary<string, string> {
+                    ["query"] = "telegram search"
+                },
+                new ToolContext {
+                    ChatId = -100123,
+                    UserId = 456,
+                    MessageId = 789
+                });
+
+            Assert.Equal("ok", result);
+            Assert.NotNull(forwardedArguments);
+            Assert.Equal("telegram search", forwardedArguments!["query"]);
+            Assert.Equal("-100123", forwardedArguments["__chatId"]);
+            Assert.Equal("456", forwardedArguments["__userId"]);
+            Assert.Equal("789", forwardedArguments["__messageId"]);
+        }
+    }
+}

--- a/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
@@ -710,7 +710,14 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
             // Check if this is a proxy tool (routed to remote process via IPC)
             if (ProxyToolRegistry.ContainsKey(toolName) && _proxyToolExecutor != null) {
-                var proxyResult = await _proxyToolExecutor(toolName, stringArguments);
+                var proxyArguments = new Dictionary<string, string>(stringArguments, StringComparer.OrdinalIgnoreCase);
+                if (toolContext != null) {
+                    proxyArguments["__chatId"] = toolContext.ChatId.ToString(CultureInfo.InvariantCulture);
+                    proxyArguments["__userId"] = toolContext.UserId.ToString(CultureInfo.InvariantCulture);
+                    proxyArguments["__messageId"] = toolContext.MessageId.ToString(CultureInfo.InvariantCulture);
+                }
+
+                var proxyResult = await _proxyToolExecutor(toolName, proxyArguments);
                 return proxyResult;
             }
 

--- a/TelegramSearchBot.LLMAgent/LLMAgentProgram.cs
+++ b/TelegramSearchBot.LLMAgent/LLMAgentProgram.cs
@@ -29,7 +29,6 @@ namespace TelegramSearchBot.LLMAgent {
             var logger = services.GetRequiredService<ILoggerFactory>().CreateLogger("LLMAgent");
             McpToolHelper.EnsureInitialized(
                 typeof(Service.AgentToolService).Assembly,
-                typeof(FileToolService).Assembly,
                 services, logger);
 
             // Import tool definitions from Redis and register as proxy tools
@@ -104,6 +103,7 @@ namespace TelegramSearchBot.LLMAgent {
             services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect($"localhost:{port},abortConnect=false,connectTimeout=5000,connectRetry=5"));
             services.AddScoped<IMessageExtensionService, Service.InMemoryMessageExtensionService>();
             services.AddScoped<OpenAIService>();
+            services.AddScoped<OpenAIResponsesService>();
             services.AddScoped<OllamaService>();
             services.AddScoped<GeminiService>();
             services.AddScoped<AnthropicService>();


### PR DESCRIPTION
## Summary
- stop LLMAgent from scanning the whole LLM assembly as local tools, so exported main-process tools are registered as proxy tools instead of being shadowed by incomplete child-process DI
- forward ToolContext metadata through proxy tool calls so the main process can execute context-sensitive tools with the original chat/user/message ids
- register OpenAIResponsesService in the LLMAgent service provider

## Validation
- dotnet test TelegramSearchBot.LLM.Test\TelegramSearchBot.LLM.Test.csproj --configuration Release --no-restore
- dotnet test TelegramSearchBot.Test\TelegramSearchBot.Test.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Agent"
- dotnet build TelegramSearchBot.sln --configuration Release --no-restore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added validation tests for service registration and initialization
  * Added tests for proxy tool context metadata forwarding

* **Bug Fixes**
  * Improved proxy tool execution to properly forward context metadata to downstream services
  * Enhanced service configuration to ensure all required components are registered

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModerRAS/TelegramSearchBot/pull/349)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->