### PR TITLE
refactor(llm): separate identity and provider resolution

### DIFF
--- a/TelegramSearchBot.LLM.Test/Service/AI/LLM/GeneralLLMServiceTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/AI/LLM/GeneralLLMServiceTests.cs
@@ -74,10 +74,6 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
                 _redisMock.Object,
                 _dbContext,
                 _loggerMock.Object,
-                _ollamaServiceMock.Object,
-                _openAIServiceMock.Object,
-                _geminiServiceMock.Object,
-                anthropicServiceMock.Object,
                 _factoryMock.Object);
         }
 

--- a/TelegramSearchBot.LLM.Test/Service/AI/LLM/LLMFactoryTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/AI/LLM/LLMFactoryTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using StackExchange.Redis;
@@ -55,15 +56,17 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
             var responsesService = new OpenAIResponsesService(
                 _dbContext, responsesLogger.Object, messageExtensionServiceMock.Object, httpClientFactoryMock.Object);
 
+            var services = new ServiceCollection()
+                .AddSingleton(_openAIServiceMock.Object)
+                .AddSingleton(_ollamaServiceMock.Object)
+                .AddSingleton(_geminiServiceMock.Object)
+                .AddSingleton(anthropicServiceMock.Object)
+                .AddSingleton(responsesService)
+                .BuildServiceProvider();
+
             _factory = new LLMFactory(
-                _redisMock.Object,
-                _dbContext,
-                _loggerMock.Object,
-                _ollamaServiceMock.Object,
-                _openAIServiceMock.Object,
-                _geminiServiceMock.Object,
-                anthropicServiceMock.Object,
-                responsesService);
+                services,
+                _loggerMock.Object);
         }
 
         [Fact]

--- a/TelegramSearchBot.LLM/Interface/AI/LLM/IBotIdentityProvider.cs
+++ b/TelegramSearchBot.LLM/Interface/AI/LLM/IBotIdentityProvider.cs
@@ -1,0 +1,11 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TelegramSearchBot.Interface.AI.LLM {
+    public interface IBotIdentityProvider {
+        Task<BotIdentity> GetIdentityAsync(CancellationToken cancellationToken = default);
+        void SetIdentity(long botUserId, string botName);
+    }
+
+    public sealed record BotIdentity(long UserId, string UserName);
+}

--- a/TelegramSearchBot.LLM/Interface/AI/LLM/IGroupLlmSettingsService.cs
+++ b/TelegramSearchBot.LLM/Interface/AI/LLM/IGroupLlmSettingsService.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace TelegramSearchBot.Interface.AI.LLM {
+    public interface IGroupLlmSettingsService {
+        Task<string> GetModelAsync(long chatId, CancellationToken cancellationToken = default);
+        Task<(string Previous, string Current)> SetModelAsync(long chatId, string modelName, CancellationToken cancellationToken = default);
+    }
+}

--- a/TelegramSearchBot.LLM/Interface/AI/LLM/IGroupLlmSettingsService.cs
+++ b/TelegramSearchBot.LLM/Interface/AI/LLM/IGroupLlmSettingsService.cs
@@ -1,9 +1,11 @@
 using System.Threading;
 using System.Threading.Tasks;
 
+#nullable enable
+
 namespace TelegramSearchBot.Interface.AI.LLM {
     public interface IGroupLlmSettingsService {
-        Task<string> GetModelAsync(long chatId, CancellationToken cancellationToken = default);
+        Task<string?> GetModelAsync(long chatId, CancellationToken cancellationToken = default);
         Task<(string Previous, string Current)> SetModelAsync(long chatId, string modelName, CancellationToken cancellationToken = default);
     }
 }

--- a/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
@@ -36,7 +36,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private string _fallbackBotName = string.Empty;
 
         public string BotName {
-            get => GetBotNameAsync().GetAwaiter().GetResult();
+            get => GetBotNameAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             set {
                 if (_botIdentityProvider != null) {
                     _botIdentityProvider.SetIdentity(Env.BotId, value);

--- a/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
@@ -32,11 +32,18 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly DataDbContext _dbContext;
         private readonly IMessageExtensionService _messageExtensionService;
         private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IBotIdentityProvider _botIdentityProvider;
+        private string _fallbackBotName = string.Empty;
 
-        public static string _botName;
         public string BotName {
-            get => _botName;
-            set => _botName = value;
+            get => GetBotNameAsync().GetAwaiter().GetResult();
+            set {
+                if (_botIdentityProvider != null) {
+                    _botIdentityProvider.SetIdentity(Env.BotId, value);
+                } else {
+                    _fallbackBotName = value ?? string.Empty;
+                }
+            }
         }
 
         private static readonly string[] _anthropicModels = {
@@ -53,12 +60,31 @@ namespace TelegramSearchBot.Service.AI.LLM {
             DataDbContext context,
             ILogger<AnthropicService> logger,
             IMessageExtensionService messageExtensionService,
-            IHttpClientFactory httpClientFactory) {
+            IHttpClientFactory httpClientFactory)
+            : this(context, logger, messageExtensionService, httpClientFactory, null) {
+        }
+
+        public AnthropicService(
+            DataDbContext context,
+            ILogger<AnthropicService> logger,
+            IMessageExtensionService messageExtensionService,
+            IHttpClientFactory httpClientFactory,
+            IBotIdentityProvider botIdentityProvider) {
             _logger = logger;
             _dbContext = context;
             _messageExtensionService = messageExtensionService;
             _httpClientFactory = httpClientFactory;
+            _botIdentityProvider = botIdentityProvider;
             _logger.LogInformation("AnthropicService instance created. McpToolHelper should be initialized at application startup.");
+        }
+
+        private async Task<string> GetBotNameAsync() {
+            if (_botIdentityProvider == null) {
+                return _fallbackBotName;
+            }
+
+            var identity = await _botIdentityProvider.GetIdentityAsync();
+            return identity.UserName ?? string.Empty;
         }
 
         private AnthropicClient CreateClient(LLMChannel channel) {
@@ -496,7 +522,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
             List<OpenAI.Chat.ChatTool> nativeTools,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
 
-            string systemPrompt = McpToolHelper.FormatSystemPromptForNativeToolCalling(BotName, ChatId);
+            var botName = await GetBotNameAsync();
+            string systemPrompt = McpToolHelper.FormatSystemPromptForNativeToolCalling(botName, ChatId);
             bool supportsVision = await CheckVisionSupport(modelName, channel.Id);
             var (_, providerHistory) = await GetChatHistory(ChatId, systemPrompt, message, supportsVision);
 
@@ -663,7 +690,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
             LlmExecutionContext executionContext,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
 
-            string systemPrompt = McpToolHelper.FormatSystemPrompt(BotName, ChatId);
+            var botName = await GetBotNameAsync();
+            string systemPrompt = McpToolHelper.FormatSystemPrompt(botName, ChatId);
             bool supportsVision = await CheckVisionSupport(modelName, channel.Id);
             var (_, providerHistory) = await GetChatHistory(ChatId, systemPrompt, message, supportsVision);
 

--- a/TelegramSearchBot.LLM/Service/AI/LLM/BotIdentityProvider.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/BotIdentityProvider.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Common;
+using TelegramSearchBot.Interface;
+using TelegramSearchBot.Interface.AI.LLM;
+
+namespace TelegramSearchBot.Service.AI.LLM {
+    [Injectable(ServiceLifetime.Singleton)]
+    public class BotIdentityProvider : IService, IBotIdentityProvider {
+        private readonly object _lock = new();
+        private BotIdentity _identity = new(0, string.Empty);
+
+        public string ServiceName => nameof(BotIdentityProvider);
+
+        public Task<BotIdentity> GetIdentityAsync(CancellationToken cancellationToken = default) {
+            lock (_lock) {
+                return Task.FromResult(_identity);
+            }
+        }
+
+        public void SetIdentity(long botUserId, string botName) {
+            lock (_lock) {
+                _identity = new BotIdentity(botUserId, botName ?? string.Empty);
+                Env.BotId = botUserId;
+            }
+        }
+    }
+}

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
@@ -32,7 +32,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly IBotIdentityProvider _botIdentityProvider;
         private string _fallbackBotName = string.Empty;
         public string BotName {
-            get => GetBotNameAsync().GetAwaiter().GetResult();
+            get => GetBotNameAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             set {
                 if (_botIdentityProvider != null) {
                     _botIdentityProvider.SetIdentity(Env.BotId, value);

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
@@ -29,16 +29,45 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly DataDbContext _dbContext;
         private readonly Dictionary<long, ChatSession> _chatSessions = new();
         private readonly IHttpClientFactory _httpClientFactory;
-        public string BotName { get; set; }
+        private readonly IBotIdentityProvider _botIdentityProvider;
+        private string _fallbackBotName = string.Empty;
+        public string BotName {
+            get => GetBotNameAsync().GetAwaiter().GetResult();
+            set {
+                if (_botIdentityProvider != null) {
+                    _botIdentityProvider.SetIdentity(Env.BotId, value);
+                } else {
+                    _fallbackBotName = value ?? string.Empty;
+                }
+            }
+        }
 
         public GeminiService(
             DataDbContext context,
             ILogger<GeminiService> logger,
-            IHttpClientFactory httpClientFactory) {
+            IHttpClientFactory httpClientFactory)
+            : this(context, logger, httpClientFactory, null) {
+        }
+
+        public GeminiService(
+            DataDbContext context,
+            ILogger<GeminiService> logger,
+            IHttpClientFactory httpClientFactory,
+            IBotIdentityProvider botIdentityProvider) {
             _logger = logger;
             _dbContext = context;
             _httpClientFactory = httpClientFactory;
+            _botIdentityProvider = botIdentityProvider;
             _logger.LogInformation("GeminiService instance created");
+        }
+
+        private async Task<string> GetBotNameAsync() {
+            if (_botIdentityProvider == null) {
+                return _fallbackBotName;
+            }
+
+            var identity = await _botIdentityProvider.GetIdentityAsync();
+            return identity.UserName ?? string.Empty;
         }
 
         private void AddMessageToHistory(List<GenerativeAI.Types.Content> chatHistory, long fromUserId, string content) {
@@ -369,7 +398,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
             var currentMessageBuilder = new StringBuilder();
             // Track history for snapshot
             var trackedHistory = new List<SerializedChatMessage>();
-            trackedHistory.Add(new SerializedChatMessage { Role = "system", Content = McpToolHelper.FormatSystemPrompt(null, ChatId) });
+            var botName = await GetBotNameAsync();
+            trackedHistory.Add(new SerializedChatMessage { Role = "system", Content = McpToolHelper.FormatSystemPrompt(botName, ChatId) });
 
             for (int cycle = 0; cycle < maxToolCycles; cycle++) {
                 if (cancellationToken.IsCancellationRequested) throw new TaskCanceledException();

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GeneralLLMService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GeneralLLMService.cs
@@ -18,10 +18,6 @@ namespace TelegramSearchBot.Service.AI.LLM {
     public class GeneralLLMService : IService, IGeneralLLMService {
         protected IConnectionMultiplexer connectionMultiplexer { get; set; }
         private readonly DataDbContext _dbContext;
-        private readonly OpenAIService _openAIService;
-        private readonly OllamaService _ollamaService;
-        private readonly GeminiService _geminiService;
-        private readonly AnthropicService _anthropicService;
         private readonly ILogger<GeneralLLMService> _logger;
         private readonly ILLMFactory _LLMFactory;
 
@@ -40,21 +36,11 @@ namespace TelegramSearchBot.Service.AI.LLM {
             IConnectionMultiplexer connectionMultiplexer,
             DataDbContext dbContext,
             ILogger<GeneralLLMService> logger,
-            OllamaService ollamaService,
-            OpenAIService openAIService,
-            GeminiService geminiService,
-            AnthropicService anthropicService,
             ILLMFactory _LLMFactory
             ) {
             this.connectionMultiplexer = connectionMultiplexer;
             _dbContext = dbContext;
             _logger = logger;
-
-            // Initialize services with default values
-            _openAIService = openAIService;
-            _ollamaService = ollamaService;
-            _geminiService = geminiService;
-            _anthropicService = anthropicService;
             this._LLMFactory = _LLMFactory;
         }
         public async Task<List<LLMChannel>> GetChannelsAsync(string modelName) {

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GroupLlmSettingsService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GroupLlmSettingsService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -8,8 +9,10 @@ using TelegramSearchBot.Interface.AI.LLM;
 using TelegramSearchBot.Model;
 using TelegramSearchBot.Model.Data;
 
+#nullable enable
+
 namespace TelegramSearchBot.Service.AI.LLM {
-    [Injectable(ServiceLifetime.Transient)]
+    [Injectable(ServiceLifetime.Scoped)]
     public class GroupLlmSettingsService : IService, IGroupLlmSettingsService {
         private readonly DataDbContext _dbContext;
 
@@ -19,27 +22,49 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
         public string ServiceName => nameof(GroupLlmSettingsService);
 
-        public async Task<string> GetModelAsync(long chatId, CancellationToken cancellationToken = default) {
+        public async Task<string?> GetModelAsync(long chatId, CancellationToken cancellationToken = default) {
             var settings = await _dbContext.GroupSettings.AsNoTracking()
                 .FirstOrDefaultAsync(s => s.GroupId == chatId, cancellationToken);
             return settings == null ? null : settings.LLMModelName;
         }
 
         public async Task<(string Previous, string Current)> SetModelAsync(long chatId, string modelName, CancellationToken cancellationToken = default) {
+            var normalizedModelName = modelName?.Trim();
+            if (string.IsNullOrWhiteSpace(normalizedModelName)) {
+                throw new ArgumentException("Model name cannot be empty.", nameof(modelName));
+            }
+
+            modelName = normalizedModelName;
             var settings = await _dbContext.GroupSettings
                 .FirstOrDefaultAsync(s => s.GroupId == chatId, cancellationToken);
             var previous = settings == null ? null : settings.LLMModelName;
+            GroupSettings? newSettings = null;
 
             if (settings is null) {
-                await _dbContext.GroupSettings.AddAsync(new GroupSettings {
+                newSettings = new GroupSettings {
                     GroupId = chatId,
                     LLMModelName = modelName
-                }, cancellationToken);
+                };
+                await _dbContext.GroupSettings.AddAsync(newSettings, cancellationToken);
             } else {
                 settings.LLMModelName = modelName;
             }
 
-            await _dbContext.SaveChangesAsync(cancellationToken);
+            try {
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            } catch (DbUpdateException) when (newSettings != null) {
+                _dbContext.Entry(newSettings).State = EntityState.Detached;
+                settings = await _dbContext.GroupSettings
+                    .FirstOrDefaultAsync(s => s.GroupId == chatId, cancellationToken);
+                if (settings is null) {
+                    throw;
+                }
+
+                previous = settings.LLMModelName;
+                settings.LLMModelName = modelName;
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+
             return (previous ?? "Default", modelName);
         }
     }

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GroupLlmSettingsService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GroupLlmSettingsService.cs
@@ -1,0 +1,46 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Interface;
+using TelegramSearchBot.Interface.AI.LLM;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Model.Data;
+
+namespace TelegramSearchBot.Service.AI.LLM {
+    [Injectable(ServiceLifetime.Transient)]
+    public class GroupLlmSettingsService : IService, IGroupLlmSettingsService {
+        private readonly DataDbContext _dbContext;
+
+        public GroupLlmSettingsService(DataDbContext dbContext) {
+            _dbContext = dbContext;
+        }
+
+        public string ServiceName => nameof(GroupLlmSettingsService);
+
+        public async Task<string> GetModelAsync(long chatId, CancellationToken cancellationToken = default) {
+            var settings = await _dbContext.GroupSettings.AsNoTracking()
+                .FirstOrDefaultAsync(s => s.GroupId == chatId, cancellationToken);
+            return settings == null ? null : settings.LLMModelName;
+        }
+
+        public async Task<(string Previous, string Current)> SetModelAsync(long chatId, string modelName, CancellationToken cancellationToken = default) {
+            var settings = await _dbContext.GroupSettings
+                .FirstOrDefaultAsync(s => s.GroupId == chatId, cancellationToken);
+            var previous = settings == null ? null : settings.LLMModelName;
+
+            if (settings is null) {
+                await _dbContext.GroupSettings.AddAsync(new GroupSettings {
+                    GroupId = chatId,
+                    LLMModelName = modelName
+                }, cancellationToken);
+            } else {
+                settings.LLMModelName = modelName;
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return (previous ?? "Default", modelName);
+        }
+    }
+}

--- a/TelegramSearchBot.LLM/Service/AI/LLM/LLMFactory.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/LLMFactory.cs
@@ -1,64 +1,40 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using StackExchange.Redis;
 using TelegramSearchBot.Attributes;
 using TelegramSearchBot.Interface;
 using TelegramSearchBot.Interface.AI.LLM;
-using TelegramSearchBot.Model;
 using TelegramSearchBot.Model.AI;
-using static GenerativeAI.VertexAIModels;
 
 namespace TelegramSearchBot.Service.AI.LLM {
-    [Injectable(Microsoft.Extensions.DependencyInjection.ServiceLifetime.Singleton)]
+    [Injectable(ServiceLifetime.Transient)]
     public class LLMFactory : IService, ILLMFactory {
         public string ServiceName => "LLMFactory";
 
-        protected IConnectionMultiplexer connectionMultiplexer { get; set; }
-        private readonly DataDbContext _dbContext;
-        private readonly OpenAIService _openAIService;
-        private readonly OllamaService _ollamaService;
-        private readonly GeminiService _geminiService;
-        private readonly AnthropicService _anthropicService;
-        private readonly OpenAIResponsesService _openAIResponsesService;
+        private readonly IServiceProvider _serviceProvider;
         private readonly ILogger<LLMFactory> _logger;
-        private readonly Dictionary<LLMProvider, ILLMService> _services;
-        public LLMFactory(
-            IConnectionMultiplexer connectionMultiplexer,
-            DataDbContext dbContext,
-            ILogger<LLMFactory> logger,
-            OllamaService ollamaService,
-            OpenAIService openAIService,
-            GeminiService geminiService,
-            AnthropicService anthropicService,
-            OpenAIResponsesService openAIResponsesService
-            ) {
-            this.connectionMultiplexer = connectionMultiplexer;
-            _dbContext = dbContext;
-            _logger = logger;
 
-            // Initialize services with default values
-            _openAIService = openAIService;
-            _ollamaService = ollamaService;
-            _geminiService = geminiService;
-            _anthropicService = anthropicService;
-            _openAIResponsesService = openAIResponsesService;
-            _services = new() {
-                [LLMProvider.OpenAI] = _openAIService,
-                [LLMProvider.Ollama] = _ollamaService,
-                [LLMProvider.Gemini] = _geminiService,
-                [LLMProvider.MiniMax] = _openAIService,
-                [LLMProvider.LMStudio] = _openAIService,
-                [LLMProvider.Anthropic] = _anthropicService,
-                [LLMProvider.ResponsesAPI] = _openAIResponsesService
-            };
+        public LLMFactory(
+            IServiceProvider serviceProvider,
+            ILogger<LLMFactory> logger
+            ) {
+            _logger = logger;
+            _serviceProvider = serviceProvider;
         }
 
-        public ILLMService GetLLMService(LLMProvider provider) => _services[provider];
+        public ILLMService GetLLMService(LLMProvider provider) {
+            return provider switch {
+                LLMProvider.OpenAI => _serviceProvider.GetRequiredService<OpenAIService>(),
+                LLMProvider.Ollama => _serviceProvider.GetRequiredService<OllamaService>(),
+                LLMProvider.Gemini => _serviceProvider.GetRequiredService<GeminiService>(),
+                LLMProvider.MiniMax => _serviceProvider.GetRequiredService<OpenAIService>(),
+                LLMProvider.LMStudio => _serviceProvider.GetRequiredService<OpenAIService>(),
+                LLMProvider.Anthropic => _serviceProvider.GetRequiredService<AnthropicService>(),
+                LLMProvider.ResponsesAPI => _serviceProvider.GetRequiredService<OpenAIResponsesService>(),
+                _ => throw new KeyNotFoundException($"No LLM service registered for provider {provider}.")
+            };
+        }
 
     }
 }

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OllamaService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OllamaService.cs
@@ -37,7 +37,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly IBotIdentityProvider _botIdentityProvider;
         private string _fallbackBotName = string.Empty;
         public string BotName {
-            get => GetBotNameAsync().GetAwaiter().GetResult();
+            get => GetBotNameAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             set {
                 if (_botIdentityProvider != null) {
                     _botIdentityProvider.SetIdentity(Env.BotId, value);

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OllamaService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OllamaService.cs
@@ -34,19 +34,49 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly DataDbContext _dbContext;
         private readonly IServiceProvider _serviceProvider;
         private readonly IHttpClientFactory _httpClientFactory;
-        public string BotName { get; set; }
+        private readonly IBotIdentityProvider _botIdentityProvider;
+        private string _fallbackBotName = string.Empty;
+        public string BotName {
+            get => GetBotNameAsync().GetAwaiter().GetResult();
+            set {
+                if (_botIdentityProvider != null) {
+                    _botIdentityProvider.SetIdentity(Env.BotId, value);
+                } else {
+                    _fallbackBotName = value ?? string.Empty;
+                }
+            }
+        }
+
+        public OllamaService(
+            DataDbContext context,
+            ILogger<OllamaService> logger,
+            IServiceProvider serviceProvider,
+            IHttpClientFactory httpClientFactory)
+            : this(context, logger, serviceProvider, httpClientFactory, null) {
+        }
 
         // Constructor requires dependencies needed directly by this class
         public OllamaService(
             DataDbContext context,
             ILogger<OllamaService> logger,
             IServiceProvider serviceProvider,
-            IHttpClientFactory httpClientFactory) {
+            IHttpClientFactory httpClientFactory,
+            IBotIdentityProvider botIdentityProvider) {
             _logger = logger;
             _dbContext = context;
             _serviceProvider = serviceProvider;
             _httpClientFactory = httpClientFactory;
+            _botIdentityProvider = botIdentityProvider;
             _logger.LogInformation("OllamaService instance created. McpToolHelper should be initialized at application startup.");
+        }
+
+        private async Task<string> GetBotNameAsync() {
+            if (_botIdentityProvider == null) {
+                return _fallbackBotName;
+            }
+
+            var identity = await _botIdentityProvider.GetIdentityAsync();
+            return identity.UserName ?? string.Empty;
         }
 
         // --- Helper methods specific to this service ---
@@ -122,7 +152,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
             // --- History and Prompt Setup ---
             // NOTE: History context is limited as OllamaSharp.Chat manages it.
-            var systemPrompt = McpToolHelper.FormatSystemPrompt(BotName, ChatId);
+            var botName = await GetBotNameAsync();
+            var systemPrompt = McpToolHelper.FormatSystemPrompt(botName, ChatId);
 
             var chat = new OllamaSharp.Chat(ollama, systemPrompt);
 

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIResponsesService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIResponsesService.cs
@@ -49,10 +49,17 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         private readonly ILogger<OpenAIResponsesService> _logger;
-        private static string _botName;
+        private readonly IBotIdentityProvider _botIdentityProvider;
+        private string _fallbackBotName = string.Empty;
         public string BotName {
-            get => _botName;
-            set => _botName = value;
+            get => GetBotNameAsync().GetAwaiter().GetResult();
+            set {
+                if (_botIdentityProvider != null) {
+                    _botIdentityProvider.SetIdentity(Env.BotId, value);
+                } else {
+                    _fallbackBotName = value ?? string.Empty;
+                }
+            }
         }
         private readonly DataDbContext _dbContext;
         private readonly IHttpClientFactory _httpClientFactory;
@@ -62,12 +69,31 @@ namespace TelegramSearchBot.Service.AI.LLM {
             DataDbContext context,
             ILogger<OpenAIResponsesService> logger,
             IMessageExtensionService messageExtensionService,
-            IHttpClientFactory httpClientFactory) {
+            IHttpClientFactory httpClientFactory)
+            : this(context, logger, messageExtensionService, httpClientFactory, null) {
+        }
+
+        public OpenAIResponsesService(
+            DataDbContext context,
+            ILogger<OpenAIResponsesService> logger,
+            IMessageExtensionService messageExtensionService,
+            IHttpClientFactory httpClientFactory,
+            IBotIdentityProvider botIdentityProvider) {
             _logger = logger;
             _dbContext = context;
             _messageExtensionService = messageExtensionService;
             _httpClientFactory = httpClientFactory;
+            _botIdentityProvider = botIdentityProvider;
             _logger.LogInformation("OpenAIResponsesService instance created.");
+        }
+
+        private async Task<string> GetBotNameAsync() {
+            if (_botIdentityProvider == null) {
+                return _fallbackBotName;
+            }
+
+            var identity = await _botIdentityProvider.GetIdentityAsync();
+            return identity.UserName ?? string.Empty;
         }
 
         // ========================================================================
@@ -114,7 +140,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
 
             // --- Build system instructions ---
-            string instructions = McpToolHelper.FormatSystemPromptForNativeToolCalling(BotName, ChatId);
+            var botName = await GetBotNameAsync();
+            string instructions = McpToolHelper.FormatSystemPromptForNativeToolCalling(botName, ChatId);
 
             // --- Get native tool definitions and convert to ResponseTool format ---
             var nativeToolDefs = McpToolHelper.GetNativeToolDefinitions();
@@ -320,7 +347,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
             var inputItems = DeserializeResponseItemsFromSnapshot(snapshot.ProviderHistory);
 
             // Restore instructions
-            string instructions = McpToolHelper.FormatSystemPromptForNativeToolCalling(BotName, snapshot.ChatId);
+            var botName = await GetBotNameAsync();
+            string instructions = McpToolHelper.FormatSystemPromptForNativeToolCalling(botName, snapshot.ChatId);
 
             // Get tools
             var nativeToolDefs = McpToolHelper.GetNativeToolDefinitions();

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIResponsesService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIResponsesService.cs
@@ -52,7 +52,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly IBotIdentityProvider _botIdentityProvider;
         private string _fallbackBotName = string.Empty;
         public string BotName {
-            get => GetBotNameAsync().GetAwaiter().GetResult();
+            get => GetBotNameAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             set {
                 if (_botIdentityProvider != null) {
                     _botIdentityProvider.SetIdentity(Env.BotId, value);

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
@@ -106,7 +106,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         public string BotName {
-            get => GetBotNameAsync().GetAwaiter().GetResult();
+            get => GetBotNameAsync().ConfigureAwait(false).GetAwaiter().GetResult();
             set {
                 if (_botIdentityProvider != null) {
                     _botIdentityProvider.SetIdentity(Env.BotId, value);

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
@@ -74,29 +74,55 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         private readonly ILogger<OpenAIService> _logger;
-        public static string _botName;
-        public string BotName {
-            get {
-                return _botName;
-            }
-            set {
-                _botName = value;
-            }
-        }
         private readonly DataDbContext _dbContext;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IMessageExtensionService _messageExtensionService;
+        private readonly IBotIdentityProvider _botIdentityProvider;
+        private readonly IGroupLlmSettingsService _groupLlmSettingsService;
+        private string _fallbackBotName = string.Empty;
 
         public OpenAIService(
             DataDbContext context,
             ILogger<OpenAIService> logger,
             IMessageExtensionService messageExtensionService,
-            IHttpClientFactory httpClientFactory) {
+            IHttpClientFactory httpClientFactory)
+            : this(context, logger, messageExtensionService, httpClientFactory, null, null) {
+        }
+
+        public OpenAIService(
+            DataDbContext context,
+            ILogger<OpenAIService> logger,
+            IMessageExtensionService messageExtensionService,
+            IHttpClientFactory httpClientFactory,
+            IBotIdentityProvider botIdentityProvider,
+            IGroupLlmSettingsService groupLlmSettingsService) {
             _logger = logger;
             _dbContext = context;
             _messageExtensionService = messageExtensionService;
             _httpClientFactory = httpClientFactory;
+            _botIdentityProvider = botIdentityProvider;
+            _groupLlmSettingsService = groupLlmSettingsService;
             _logger.LogInformation("OpenAIService instance created. McpToolHelper should be initialized at application startup.");
+        }
+
+        public string BotName {
+            get => GetBotNameAsync().GetAwaiter().GetResult();
+            set {
+                if (_botIdentityProvider != null) {
+                    _botIdentityProvider.SetIdentity(Env.BotId, value);
+                } else {
+                    _fallbackBotName = value ?? string.Empty;
+                }
+            }
+        }
+
+        private async Task<string> GetBotNameAsync() {
+            if (_botIdentityProvider == null) {
+                return _fallbackBotName;
+            }
+
+            var identity = await _botIdentityProvider.GetIdentityAsync();
+            return identity.UserName ?? string.Empty;
         }
 
         public virtual async Task<IEnumerable<string>> GetAllModels(LLMChannel channel) {
@@ -971,7 +997,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
 
             // --- History and Prompt Setup (simplified - no XML tool instructions) ---
-            string systemPrompt = McpToolHelper.FormatSystemPromptForNativeToolCalling(BotName, ChatId);
+            var botName = await GetBotNameAsync();
+            string systemPrompt = McpToolHelper.FormatSystemPromptForNativeToolCalling(botName, ChatId);
             List<ChatMessage> providerHistory = new List<ChatMessage>() { new SystemChatMessage(systemPrompt) };
             bool supportsVision = await CheckVisionSupport(modelName, channel.Id);
             providerHistory = await GetChatHistory(ChatId, providerHistory, message, supportsVision);
@@ -1153,7 +1180,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
 
             // --- History and Prompt Setup ---
-            string systemPrompt = McpToolHelper.FormatSystemPrompt(BotName, ChatId);
+            var botName = await GetBotNameAsync();
+            string systemPrompt = McpToolHelper.FormatSystemPrompt(botName, ChatId);
             List<ChatMessage> providerHistory = new List<ChatMessage>() { new SystemChatMessage(systemPrompt) };
             bool supportsVision = await CheckVisionSupport(modelName, channel.Id);
             providerHistory = await GetChatHistory(ChatId, providerHistory, message, supportsVision);
@@ -1584,6 +1612,11 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         public async Task<(string, string)> SetModel(string ModelName, long ChatId) {
+            if (_groupLlmSettingsService != null) {
+                var (previous, current) = await _groupLlmSettingsService.SetModelAsync(ChatId, ModelName);
+                return (previous, current);
+            }
+
             var GroupSetting = await _dbContext.GroupSettings
                                 .Where(s => s.GroupId == ChatId)
                                 .FirstOrDefaultAsync();
@@ -1597,6 +1630,10 @@ namespace TelegramSearchBot.Service.AI.LLM {
             return (CurrentModelName ?? "Default", ModelName);
         }
         public async Task<string> GetModel(long ChatId) {
+            if (_groupLlmSettingsService != null) {
+                return await _groupLlmSettingsService.GetModelAsync(ChatId);
+            }
+
             var GroupSetting = await _dbContext.GroupSettings.AsNoTracking()
                                       .Where(s => s.GroupId == ChatId)
                                       .FirstOrDefaultAsync();

--- a/TelegramSearchBot.LLMAgent/LLMAgentProgram.cs
+++ b/TelegramSearchBot.LLMAgent/LLMAgentProgram.cs
@@ -102,6 +102,8 @@ namespace TelegramSearchBot.LLMAgent {
             }, contextLifetime: ServiceLifetime.Scoped, optionsLifetime: ServiceLifetime.Singleton);
             services.AddSingleton<IConnectionMultiplexer>(_ => ConnectionMultiplexer.Connect($"localhost:{port},abortConnect=false,connectTimeout=5000,connectRetry=5"));
             services.AddScoped<IMessageExtensionService, Service.InMemoryMessageExtensionService>();
+            services.AddSingleton<IBotIdentityProvider, BotIdentityProvider>();
+            services.AddScoped<IGroupLlmSettingsService, GroupLlmSettingsService>();
             services.AddScoped<OpenAIService>();
             services.AddScoped<OpenAIResponsesService>();
             services.AddScoped<OllamaService>();

--- a/TelegramSearchBot.LLMAgent/Service/LlmServiceProxy.cs
+++ b/TelegramSearchBot.LLMAgent/Service/LlmServiceProxy.cs
@@ -25,7 +25,7 @@ namespace TelegramSearchBot.LLMAgent.Service {
             await SeedTaskDataAsync(task, cancellationToken);
 
             var service = ResolveService(task.Channel.Provider);
-            ApplyBotIdentity(service, task.BotName, task.BotUserId);
+            ApplyBotIdentity(task.BotName, task.BotUserId);
             var channel = ToEntity(task.Channel);
 
             if (task.Kind == AgentTaskKind.Continuation && task.ContinuationSnapshot != null) {
@@ -63,24 +63,12 @@ namespace TelegramSearchBot.LLMAgent.Service {
             };
         }
 
-        private static void ApplyBotIdentity(ILLMService service, string botName, long botUserId) {
-            Env.BotId = botUserId;
-            switch (service) {
-                case OpenAIService openAi:
-                    openAi.BotName = botName;
-                    break;
-                case OllamaService ollama:
-                    ollama.BotName = botName;
-                    break;
-                case GeminiService gemini:
-                    gemini.BotName = botName;
-                    break;
-                case AnthropicService anthropic:
-                    anthropic.BotName = botName;
-                    break;
-                case OpenAIResponsesService responses:
-                    responses.BotName = botName;
-                    break;
+        private void ApplyBotIdentity(string botName, long botUserId) {
+            var identityProvider = _serviceProvider.GetService<IBotIdentityProvider>();
+            if (identityProvider != null) {
+                identityProvider.SetIdentity(botUserId, botName);
+            } else {
+                Env.BotId = botUserId;
             }
         }
 

--- a/TelegramSearchBot.LLMAgent/Service/LlmServiceProxy.cs
+++ b/TelegramSearchBot.LLMAgent/Service/LlmServiceProxy.cs
@@ -68,6 +68,10 @@ namespace TelegramSearchBot.LLMAgent.Service {
             if (identityProvider != null) {
                 identityProvider.SetIdentity(botUserId, botName);
             } else {
+                _logger.LogDebug(
+                    "IBotIdentityProvider is not registered; falling back to Env.BotId for bot {BotName} ({BotUserId}).",
+                    botName,
+                    botUserId);
                 Env.BotId = botUserId;
             }
         }

--- a/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
+++ b/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
@@ -100,7 +100,13 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             }
 
             if (Message.StartsWith("设置模型 ") && fromUserId != 0 && await adminService.IsNormalAdmin(fromUserId)) {
-                var (previous, current) = await _groupLlmSettingsService.SetModelAsync(telegramMessage.Chat.Id, Message.Substring(5));
+                var requestedModelName = Message.Substring(5).Trim();
+                if (string.IsNullOrWhiteSpace(requestedModelName)) {
+                    await SendMessageService.SendMessage("模型名称不能为空", telegramMessage.Chat.Id, telegramMessage.MessageId);
+                    return;
+                }
+
+                var (previous, current) = await _groupLlmSettingsService.SetModelAsync(telegramMessage.Chat.Id, requestedModelName);
                 logger.LogInformation($"群{telegramMessage.Chat.Id}模型设置成功，原模型：{previous}，现模型：{current}。消息来源：{telegramMessage.MessageId}");
                 await SendMessageService.SendMessage($"模型设置成功，原模型：{previous}，现模型：{current}", telegramMessage.Chat.Id, telegramMessage.MessageId);
                 return;
@@ -114,6 +120,11 @@ namespace TelegramSearchBot.Controller.AI.LLM {
 
             if (isMentionToBot || isReplyToBot) {
                 var modelName = await _groupLlmSettingsService.GetModelAsync(telegramMessage.Chat.Id);
+                if (string.IsNullOrWhiteSpace(modelName)) {
+                    logger.LogWarning("请指定模型名称");
+                    return;
+                }
+
                 var initialContentPlaceholder = $"{modelName}初始化中。。。";
 
                 // Prepare the input message for GeneralLLMService

--- a/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
+++ b/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
@@ -23,8 +23,9 @@ using TelegramSearchBot.Service.Storage;
 namespace TelegramSearchBot.Controller.AI.LLM {
     public class GeneralLLMController : IOnUpdate {
         private readonly ILogger logger;
-        private readonly OpenAIService service;
         private readonly SendMessage Send;
+        private readonly IBotIdentityProvider _botIdentityProvider;
+        private readonly IGroupLlmSettingsService _groupLlmSettingsService;
         public List<Type> Dependencies => new List<Type>();
         public ITelegramBotClient botClient { get; set; }
         public MessageService messageService { get; set; }
@@ -36,18 +37,18 @@ namespace TelegramSearchBot.Controller.AI.LLM {
         public GeneralLLMController(
             MessageService messageService,
             ITelegramBotClient botClient,
-            OpenAIService openaiService,
             SendMessage Send,
             ILogger<GeneralLLMController> logger,
             AdminService adminService,
             ISendMessageService SendMessageService,
             IGeneralLLMService generalLLMService,
             ILlmContinuationService continuationService,
-            LLMTaskQueueService llmTaskQueueService
+            LLMTaskQueueService llmTaskQueueService,
+            IBotIdentityProvider botIdentityProvider,
+            IGroupLlmSettingsService groupLlmSettingsService
             ) {
             this.logger = logger;
             this.botClient = botClient;
-            service = openaiService;
             this.Send = Send;
             this.messageService = messageService;
             this.adminService = adminService;
@@ -55,89 +56,98 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             GeneralLLMService = generalLLMService;
             ContinuationService = continuationService;
             LlmTaskQueueService = llmTaskQueueService;
+            _botIdentityProvider = botIdentityProvider;
+            _groupLlmSettingsService = groupLlmSettingsService;
 
         }
         public async Task ExecuteAsync(PipelineContext p) {
             var e = p.Update;
+            var telegramMessage = e.Message;
+            if (telegramMessage == null) {
+                return;
+            }
+
             if (!Env.EnableOpenAI) {
                 return;
             }
-            if (string.IsNullOrEmpty(service.BotName)) {
+            var botIdentity = await _botIdentityProvider.GetIdentityAsync();
+            if (string.IsNullOrEmpty(botIdentity.UserName)) {
                 var me = await botClient.GetMe();
-                Env.BotId = me.Id;
-                service.BotName = me.Username; // service.BotName is the username, e.g., "MyBot"
+                _botIdentityProvider.SetIdentity(me.Id, me.Username);
+                botIdentity = new BotIdentity(me.Id, me.Username ?? string.Empty);
             }
 
-            var Message = string.IsNullOrEmpty(e?.Message?.Text) ? e?.Message?.Caption : e.Message.Text;
+            var Message = string.IsNullOrEmpty(telegramMessage.Text) ? telegramMessage.Caption : telegramMessage.Text;
             if (string.IsNullOrEmpty(Message)) {
                 return;
             }
+            var fromUserId = telegramMessage.From?.Id ?? 0;
 
             // Check if the message is a bot command specifically targeting this bot
-            // service.BotName should be initialized by the block above.
-            if (e.Message.Entities != null && !string.IsNullOrEmpty(service.BotName) &&
-                e.Message.Entities.Any(entity => entity.Type == MessageEntityType.BotCommand)) {
-                var botCommandEntity = e.Message.Entities.First(entity => entity.Type == MessageEntityType.BotCommand);
+            // Bot identity should be initialized by the block above.
+            if (telegramMessage.Entities != null && !string.IsNullOrEmpty(botIdentity.UserName) &&
+                telegramMessage.Entities.Any(entity => entity.Type == MessageEntityType.BotCommand)) {
+                var botCommandEntity = telegramMessage.Entities.First(entity => entity.Type == MessageEntityType.BotCommand);
                 // Ensure the command is at the beginning of the message
                 if (botCommandEntity.Offset == 0) {
                     string commandText = Message.Substring(botCommandEntity.Offset, botCommandEntity.Length);
                     // Check if the command text itself contains @BotName (e.g., /cmd@MyBot)
-                    if (commandText.Contains($"@{service.BotName}")) {
-                        logger.LogInformation($"Ignoring command '{commandText}' in GeneralLLMController as it's a direct command to the bot and should be handled by a dedicated command handler. MessageId: {e.Message.MessageId}");
+                    if (commandText.Contains($"@{botIdentity.UserName}")) {
+                        logger.LogInformation($"Ignoring command '{commandText}' in GeneralLLMController as it's a direct command to the bot and should be handled by a dedicated command handler. MessageId: {telegramMessage.MessageId}");
                         return; // Let other command handlers process it
                     }
                 }
             }
 
-            if (Message.StartsWith("设置模型 ") && await adminService.IsNormalAdmin(e.Message.From.Id)) {
-                var (previous, current) = await service.SetModel(Message.Substring(5), e.Message.Chat.Id);
-                logger.LogInformation($"群{e.Message.Chat.Id}模型设置成功，原模型：{previous}，现模型：{current}。消息来源：{e.Message.MessageId}");
-                await SendMessageService.SendMessage($"模型设置成功，原模型：{previous}，现模型：{current}", e.Message.Chat.Id, e.Message.MessageId);
+            if (Message.StartsWith("设置模型 ") && fromUserId != 0 && await adminService.IsNormalAdmin(fromUserId)) {
+                var (previous, current) = await _groupLlmSettingsService.SetModelAsync(telegramMessage.Chat.Id, Message.Substring(5));
+                logger.LogInformation($"群{telegramMessage.Chat.Id}模型设置成功，原模型：{previous}，现模型：{current}。消息来源：{telegramMessage.MessageId}");
+                await SendMessageService.SendMessage($"模型设置成功，原模型：{previous}，现模型：{current}", telegramMessage.Chat.Id, telegramMessage.MessageId);
                 return;
             }
 
             // Trigger LLM if:
-            // 1. Message contains an explicit mention @BotName (and service.BotName is set)
+            // 1. Message contains an explicit mention @BotName (and bot identity is set)
             // 2. Message is a reply to the bot (Env.BotId must be set)
-            bool isMentionToBot = !string.IsNullOrEmpty(service.BotName) && Message.Contains($"@{service.BotName}");
-            bool isReplyToBot = e.Message.ReplyToMessage != null && e.Message.ReplyToMessage.From != null && e.Message.ReplyToMessage.From.Id == Env.BotId;
+            bool isMentionToBot = !string.IsNullOrEmpty(botIdentity.UserName) && Message.Contains($"@{botIdentity.UserName}");
+            bool isReplyToBot = telegramMessage.ReplyToMessage != null && telegramMessage.ReplyToMessage.From != null && telegramMessage.ReplyToMessage.From.Id == botIdentity.UserId;
 
             if (isMentionToBot || isReplyToBot) {
-                var modelName = await service.GetModel(e.Message.Chat.Id);
+                var modelName = await _groupLlmSettingsService.GetModelAsync(telegramMessage.Chat.Id);
                 var initialContentPlaceholder = $"{modelName}初始化中。。。";
 
                 // Prepare the input message for GeneralLLMService
                 var inputLlMessage = new Model.Data.Message() {
                     Content = Message,
-                    DateTime = e.Message.Date,
-                    FromUserId = e.Message.From.Id,
-                    GroupId = e.Message.Chat.Id,
-                    MessageId = e.Message.MessageId,
-                    ReplyToMessageId = e.Message.ReplyToMessage?.MessageId ?? 0,
+                    DateTime = telegramMessage.Date,
+                    FromUserId = fromUserId,
+                    GroupId = telegramMessage.Chat.Id,
+                    MessageId = telegramMessage.MessageId,
+                    ReplyToMessageId = telegramMessage.ReplyToMessage?.MessageId ?? 0,
                     Id = -1,
                 };
 
                 // Use execution context to detect iteration limit (no stream pollution)
                 var executionContext = new LlmExecutionContext();
                 IAsyncEnumerable<string> fullMessageStream;
-                AgentTaskStreamHandle? agentTaskHandle = null;
+                AgentTaskStreamHandle agentTaskHandle = null;
                 if (Env.EnableLLMAgentProcess) {
                     agentTaskHandle = await LlmTaskQueueService.EnqueueMessageTaskAsync(
-                        e.Message,
-                        service.BotName,
-                        Env.BotId,
+                        telegramMessage,
+                        botIdentity.UserName,
+                        botIdentity.UserId,
                         CancellationToken.None);
                     fullMessageStream = agentTaskHandle.ReadSnapshotsAsync(CancellationToken.None);
                 } else {
                     fullMessageStream = GeneralLLMService.ExecAsync(
-                        inputLlMessage, e.Message.Chat.Id, executionContext, CancellationToken.None);
+                        inputLlMessage, telegramMessage.Chat.Id, executionContext, CancellationToken.None);
                 }
 
                 // Use sendMessageDraft API for LLM streaming (better performance, no send+edit)
                 List<Model.Data.Message> sentMessagesForDb = await SendMessageService.SendDraftStream(
                     fullMessageStream,
-                    e.Message.Chat.Id,
-                    e.Message.MessageId,
+                    telegramMessage.Chat.Id,
+                    telegramMessage.MessageId,
                     initialContentPlaceholder,
                     CancellationToken.None
                 );
@@ -149,7 +159,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
                         botUser = await botClient.GetMe();
                     }
                     await messageService.ExecuteAsync(new MessageOption() {
-                        Chat = e.Message.Chat,
+                        Chat = telegramMessage.Chat,
                         ChatId = dbMessage.GroupId,
                         Content = dbMessage.Content,
                         DateTime = dbMessage.DateTime,
@@ -163,7 +173,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
                 if (agentTaskHandle != null) {
                     var terminalChunk = await agentTaskHandle.Completion;
                     if (terminalChunk.Type == AgentChunkType.Error) {
-                        await SendMessageService.SendMessage($"AI Agent 执行失败：{terminalChunk.ErrorMessage}", e.Message.Chat.Id, e.Message.MessageId);
+                        await SendMessageService.SendMessage($"AI Agent 执行失败：{terminalChunk.ErrorMessage}", telegramMessage.Chat.Id, telegramMessage.MessageId);
                     } else if (terminalChunk.Type == AgentChunkType.IterationLimitReached && terminalChunk.ContinuationSnapshot != null) {
                         var snapshotId = await ContinuationService.SaveSnapshotAsync(terminalChunk.ContinuationSnapshot);
 
@@ -175,10 +185,10 @@ namespace TelegramSearchBot.Controller.AI.LLM {
                         });
 
                         await botClient.SendMessage(
-                            e.Message.Chat.Id,
+                            telegramMessage.Chat.Id,
                             $"⚠️ AI 已达到最大迭代次数限制（{Env.MaxToolCycles} 次），是否继续迭代？",
                             replyMarkup: keyboard,
-                            replyParameters: new ReplyParameters { MessageId = e.Message.MessageId }
+                            replyParameters: new ReplyParameters { MessageId = telegramMessage.MessageId }
                         );
                     }
 
@@ -188,7 +198,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
                 // Check if the iteration limit was reached via execution context
                 if (executionContext.IterationLimitReached && executionContext.SnapshotData != null) {
                     logger.LogInformation("Iteration limit reached for ChatId {ChatId}, MessageId {MessageId}. Saving snapshot and prompting user.",
-                        e.Message.Chat.Id, e.Message.MessageId);
+                        telegramMessage.Chat.Id, telegramMessage.MessageId);
 
                     // Save the snapshot to Redis
                     var snapshotId = await ContinuationService.SaveSnapshotAsync(executionContext.SnapshotData);
@@ -201,10 +211,10 @@ namespace TelegramSearchBot.Controller.AI.LLM {
                     });
 
                     await botClient.SendMessage(
-                        e.Message.Chat.Id,
+                        telegramMessage.Chat.Id,
                         $"⚠️ AI 已达到最大迭代次数限制（{Env.MaxToolCycles} 次），是否继续迭代？",
                         replyMarkup: keyboard,
-                        replyParameters: new ReplyParameters { MessageId = e.Message.MessageId }
+                        replyParameters: new ReplyParameters { MessageId = telegramMessage.MessageId }
                     );
                 }
 


### PR DESCRIPTION
## Summary

This PR implements the first architecture slice from #293: removing hidden provider-coupled state from the LLM entry path and making provider resolution per-operation instead of cached inside a singleton factory.

Changes:
- Introduce `IBotIdentityProvider` / `BotIdentityProvider` so bot identity is no longer stored through `OpenAIService.BotName` as shared provider state.
- Introduce `IGroupLlmSettingsService` / `GroupLlmSettingsService` so group model get/set no longer depends on `OpenAIService`.
- Update `GeneralLLMController` to depend on the identity/settings abstractions instead of injecting `OpenAIService` as a state holder.
- Change `LLMFactory` to resolve provider services from DI for each call, instead of caching provider instances in the factory.
- Remove the old concrete provider fields from `GeneralLLMService`.
- Update OpenAI/Ollama/Gemini/Anthropic/Responses providers to read bot identity through `IBotIdentityProvider`, while keeping an instance-level `BotName` compatibility fallback for direct construction/tests.
- Update the LLMAgent process to register the new services and apply bot identity through the provider abstraction.
- Adjust affected unit tests for the new factory/controller boundaries.

## Notes

This intentionally keeps the PR bounded. It does not yet introduce a full `LlmExecutionRequest` object or split all channel/model selection rules out of `GeneralLLMService`; those are better as follow-up slices after this state-boundary cleanup lands.

## Validation

- `dotnet build TelegramSearchBot.sln --configuration Release --no-restore`
- `dotnet test TelegramSearchBot.LLM.Test\TelegramSearchBot.LLM.Test.csproj --configuration Release --no-build` — 202 passed
- `dotnet test TelegramSearchBot.Test\TelegramSearchBot.Test.csproj --configuration Release --no-build --filter "FullyQualifiedName~EditLLMConf|FullyQualifiedName~Agent"` — 30 passed

Part of #293


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-group LLM model configuration: set/get model per chat.
  * Persistent bot identity: unified bot name/userid handling across services.

* **Refactor**
  * Simplified LLM provider routing and DI usage; services now resolve identities/settings via shared providers.
  * Controller now initializes and relies on centralized identity and group-model services.

* **Bug Fixes**
  * Controller skips empty messages and respects enable flags.

* **Tests**
  * Test suite updated to reflect DI and service-registration changes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ModerRAS/TelegramSearchBot/pull/350)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->