### PR TITLE
Fix LLMAgent tool definition refresh

### DIFF
--- a/TelegramSearchBot.Common/LoggerHolders.cs
+++ b/TelegramSearchBot.Common/LoggerHolders.cs
@@ -1,11 +1,24 @@
 using Serilog;
+using Serilog.Context;
+using Serilog.Events;
 
 namespace TelegramSearchBot.Common {
     /// <summary>
-    /// Shared logger holder for EF Core logging.
+    /// Shared logger holder for EF Core logging and sensitive log routing.
     /// Initialized by TelegramSearchBot.Program and used by Database project.
     /// </summary>
     public static class LoggerHolders {
+        public const string ChatContentLogPropertyName = "ContainsChatContent";
+
         public static Serilog.ILogger EfCoreLogger { get; set; } = null!;
+
+        public static IDisposable PushChatContentLogScope() {
+            return LogContext.PushProperty(ChatContentLogPropertyName, true);
+        }
+
+        public static bool IsChatContentLogEvent(LogEvent logEvent) {
+            return logEvent.Properties.TryGetValue(ChatContentLogPropertyName, out var value) &&
+                   value is ScalarValue { Value: true };
+        }
     }
 }

--- a/TelegramSearchBot.LLM.Test/Service/AI/LLM/AgentToolRegistryServiceTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/AI/LLM/AgentToolRegistryServiceTests.cs
@@ -1,0 +1,81 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using TelegramSearchBot.LLMAgent.Service;
+using TelegramSearchBot.Model.AI;
+using TelegramSearchBot.Service.AI.LLM;
+using TelegramSearchBot.Test;
+using Xunit;
+
+namespace TelegramSearchBot.LLM.Test.Service.AI.LLM {
+    [Collection(McpToolHelperTestCollection.Name)]
+    public class AgentToolRegistryServiceTests {
+        [Fact]
+        public async Task RefreshAsync_WhenDefinitionsChange_ReplacesProxyTools() {
+            var firstToolName = $"proxy_refresh_first_{Guid.NewGuid():N}";
+            var secondToolName = $"proxy_refresh_second_{Guid.NewGuid():N}";
+            var currentDefinitions = SerializeDefinitions(firstToolName);
+            var redisMock = new Mock<IConnectionMultiplexer>();
+            var dbMock = new Mock<IDatabase>();
+            redisMock.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+            dbMock.Setup(d => d.StringGetAsync(
+                    It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentToolDefs),
+                    It.IsAny<CommandFlags>()))
+                .ReturnsAsync(() => ( RedisValue ) currentDefinitions);
+
+            var registry = new AgentToolRegistryService(
+                redisMock.Object,
+                new ToolExecutor(null!, null!),
+                Mock.Of<ILogger<AgentToolRegistryService>>());
+
+            var firstRefresh = await registry.RefreshAsync();
+            Assert.True(firstRefresh);
+            Assert.True(McpToolHelper.IsToolRegistered(firstToolName));
+
+            currentDefinitions = SerializeDefinitions(secondToolName);
+            var secondRefresh = await registry.RefreshAsync();
+
+            Assert.True(secondRefresh);
+            Assert.False(McpToolHelper.IsToolRegistered(firstToolName));
+            Assert.True(McpToolHelper.IsToolRegistered(secondToolName));
+        }
+
+        [Fact]
+        public async Task RefreshAsync_WhenDefinitionsMissing_ReturnsFalse() {
+            var redisMock = new Mock<IConnectionMultiplexer>();
+            var dbMock = new Mock<IDatabase>();
+            redisMock.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+            dbMock.Setup(d => d.StringGetAsync(
+                    It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentToolDefs),
+                    It.IsAny<CommandFlags>()))
+                .ReturnsAsync(RedisValue.Null);
+
+            var registry = new AgentToolRegistryService(
+                redisMock.Object,
+                new ToolExecutor(null!, null!),
+                Mock.Of<ILogger<AgentToolRegistryService>>());
+
+            var refreshed = await registry.RefreshAsync();
+
+            Assert.False(refreshed);
+        }
+
+        private static string SerializeDefinitions(string toolName) {
+            return JsonConvert.SerializeObject(new List<ProxyToolDefinition> {
+                new() {
+                    Name = toolName,
+                    Description = "Proxy test tool.",
+                    Parameters = [
+                        new ProxyToolParameter {
+                            Name = "query",
+                            Type = "string",
+                            Description = "Query text.",
+                            Required = true
+                        }
+                    ]
+                }
+            });
+        }
+    }
+}

--- a/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
@@ -521,6 +521,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             LlmExecutionContext executionContext,
             List<OpenAI.Chat.ChatTool> nativeTools,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
 
             var botName = await GetBotNameAsync();
             string systemPrompt = McpToolHelper.FormatSystemPromptForNativeToolCalling(botName, ChatId);
@@ -718,6 +719,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             DataMessage message, long ChatId, string modelName, LLMChannel channel,
             LlmExecutionContext executionContext,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
 
             var botName = await GetBotNameAsync();
             string systemPrompt = McpToolHelper.FormatSystemPrompt(botName, ChatId);
@@ -847,6 +849,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             LlmContinuationSnapshot snapshot, LLMChannel channel,
             LlmExecutionContext executionContext,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
             if (snapshot == null) {
                 _logger.LogError("{ServiceName}: Cannot resume from null snapshot.", ServiceName);
                 yield break;

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
@@ -382,6 +382,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             LLMChannel channel,
             LlmExecutionContext executionContext,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
             if (string.IsNullOrWhiteSpace(modelName)) modelName = "gemini-1.5-flash";
 
             var googleAI = new GoogleAi(channel.ApiKey, client: _httpClientFactory.CreateClient());

--- a/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
@@ -1296,7 +1296,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             var toolDefs = ExportToolDefinitions();
             var json = JsonConvert.SerializeObject(toolDefs);
             await redis.GetDatabase().StringSetAsync(
-                LlmAgentRedisKeys.AgentToolDefs, json, TimeSpan.FromHours(24));
+                LlmAgentRedisKeys.AgentToolDefs, json);
             _sLogger?.LogInformation(
                 "Exported agent tool definitions to Redis. Count={Count}, PayloadBytes={PayloadBytes}, ToolNames={ToolNames}",
                 toolDefs.Count,

--- a/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/McpToolHelper.cs
@@ -443,6 +443,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             }
 
             try {
+                using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
                 string processedInput = input.Trim();
                 _sLogger?.LogDebug($"Original input: {processedInput}");
 
@@ -723,6 +724,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         /// Use the scoped overload when executing tools that require scoped services (e.g., DbContext).
         /// </summary>
         public static async Task<object> ExecuteRegisteredToolAsync(string toolName, Dictionary<string, string> stringArguments, IServiceProvider scopedProvider, ToolContext toolContext = null) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
             var elapsed = Stopwatch.StartNew();
             var originalArguments = stringArguments ?? new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var route = GetToolRoute(toolName);

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OllamaService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OllamaService.cs
@@ -127,6 +127,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         public async IAsyncEnumerable<string> ExecAsync(Model.Data.Message message, long ChatId, string modelName, LLMChannel channel,
                                                         LlmExecutionContext executionContext,
                                                         [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
             modelName = modelName ?? Env.OllamaModelName;
             if (string.IsNullOrWhiteSpace(modelName)) {
                 _logger.LogError("{ServiceName}: Model name is not configured.", ServiceName);

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIResponsesService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIResponsesService.cs
@@ -138,6 +138,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             Message message, long ChatId, string modelName, LLMChannel channel,
             LlmExecutionContext executionContext,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
 
             // --- Build system instructions ---
             var botName = await GetBotNameAsync();
@@ -365,6 +366,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             LlmContinuationSnapshot snapshot, LLMChannel channel,
             LlmExecutionContext executionContext,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
             if (snapshot == null) {
                 _logger.LogError("{ServiceName}: Cannot resume from null snapshot.", ServiceName);
                 yield break;

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
@@ -1039,6 +1039,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             LlmExecutionContext executionContext,
             List<ChatTool> nativeTools,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
 
             // --- History and Prompt Setup (simplified - no XML tool instructions) ---
             var botName = await GetBotNameAsync();
@@ -1299,6 +1300,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             Model.Data.Message message, long ChatId, string modelName, LLMChannel channel,
             LlmExecutionContext executionContext,
             [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
 
             // --- History and Prompt Setup ---
             var botName = await GetBotNameAsync();
@@ -1424,6 +1426,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         public async IAsyncEnumerable<string> ResumeFromSnapshotAsync(LlmContinuationSnapshot snapshot, LLMChannel channel,
                                                                        LlmExecutionContext executionContext,
                                                                        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken cancellationToken = default) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
             if (snapshot == null) {
                 _logger.LogError("{ServiceName}: Cannot resume from null snapshot.", ServiceName);
                 yield break;

--- a/TelegramSearchBot.LLM/Service/Mcp/McpClient.cs
+++ b/TelegramSearchBot.LLM/Service/Mcp/McpClient.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using TelegramSearchBot.Common;
 using TelegramSearchBot.Interface.Mcp;
 using TelegramSearchBot.Model.Mcp;
 
@@ -101,7 +102,9 @@ namespace TelegramSearchBot.Service.Mcp {
                         while (!capturedProcess.HasExited) {
                             var line = await capturedProcess.StandardError.ReadLineAsync();
                             if (line != null) {
-                                _logger.LogDebug("[MCP:{ServerName}:stderr] {Line}", ServerName, line);
+                                using (LoggerHolders.PushChatContentLogScope()) {
+                                    _logger.LogDebug("[MCP:{ServerName}:stderr] {Line}", ServerName, line);
+                                }
                             }
                         }
                     } catch { /* Process exited */ }
@@ -204,7 +207,9 @@ namespace TelegramSearchBot.Service.Mcp {
                     NullValueHandling = NullValueHandling.Ignore
                 });
 
-                _logger.LogDebug("[MCP:{ServerName}] Sending: {Json}", ServerName, json);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogDebug("[MCP:{ServerName}] Sending: {Json}", ServerName, json);
+                }
                 await _stdin.WriteLineAsync(json);
                 await _stdin.FlushAsync();
 
@@ -221,7 +226,9 @@ namespace TelegramSearchBot.Service.Mcp {
                     var responseLine = await ReadLineAsync(cts.Token);
                     if (string.IsNullOrWhiteSpace(responseLine)) continue;
 
-                    _logger.LogDebug("[MCP:{ServerName}] Received: {Json}", ServerName, responseLine);
+                    using (LoggerHolders.PushChatContentLogScope()) {
+                        _logger.LogDebug("[MCP:{ServerName}] Received: {Json}", ServerName, responseLine);
+                    }
 
                     try {
                         var response = JsonConvert.DeserializeObject<JsonRpcResponse>(responseLine);
@@ -235,7 +242,9 @@ namespace TelegramSearchBot.Service.Mcp {
                         // Not our response (could be a notification), continue reading
                     } catch (JsonException) {
                         // Not valid JSON-RPC, skip
-                        _logger.LogWarning("[MCP:{ServerName}] Received non-JSON-RPC message: {Line}", ServerName, responseLine);
+                        using (LoggerHolders.PushChatContentLogScope()) {
+                            _logger.LogWarning("[MCP:{ServerName}] Received non-JSON-RPC message: {Line}", ServerName, responseLine);
+                        }
                     }
                 }
 
@@ -258,7 +267,9 @@ namespace TelegramSearchBot.Service.Mcp {
                     NullValueHandling = NullValueHandling.Ignore
                 });
 
-                _logger.LogDebug("[MCP:{ServerName}] Sending notification: {Json}", ServerName, json);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogDebug("[MCP:{ServerName}] Sending notification: {Json}", ServerName, json);
+                }
                 await _stdin.WriteLineAsync(json);
                 await _stdin.FlushAsync();
             } finally {

--- a/TelegramSearchBot.LLMAgent/LLMAgentProgram.cs
+++ b/TelegramSearchBot.LLMAgent/LLMAgentProgram.cs
@@ -2,7 +2,6 @@ using System.Reflection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using StackExchange.Redis;
 using TelegramSearchBot.Common;
 using TelegramSearchBot.Interface;
@@ -31,9 +30,6 @@ namespace TelegramSearchBot.LLMAgent {
                 typeof(Service.AgentToolService).Assembly,
                 services, logger);
 
-            // Import tool definitions from Redis and register as proxy tools
-            await RegisterProxyToolsFromRedisAsync(services, logger);
-
             var loop = services.GetRequiredService<Service.AgentLoopService>();
             using var shutdownCts = new CancellationTokenSource();
             Console.CancelKeyPress += (_, eventArgs) => {
@@ -43,67 +39,6 @@ namespace TelegramSearchBot.LLMAgent {
             AppDomain.CurrentDomain.ProcessExit += (_, _) => shutdownCts.Cancel();
 
             await loop.RunAsync(chatId, port, shutdownCts.Token);
-        }
-
-        private static async Task RegisterProxyToolsFromRedisAsync(ServiceProvider services, ILogger logger) {
-            try {
-                var redis = services.GetRequiredService<IConnectionMultiplexer>();
-                logger.LogDebug("Loading proxy tool definitions from Redis key {RedisKey}.", LlmAgentRedisKeys.AgentToolDefs);
-                var json = await redis.GetDatabase().StringGetAsync(LlmAgentRedisKeys.AgentToolDefs);
-                if (!json.HasValue || string.IsNullOrWhiteSpace(json.ToString())) {
-                    logger.LogWarning("No tool definitions found in Redis. Agent will have limited tools.");
-                    return;
-                }
-
-                var toolDefsJson = json.ToString();
-                logger.LogDebug("Loaded proxy tool definition payload from Redis. Bytes={PayloadBytes}", System.Text.Encoding.UTF8.GetByteCount(toolDefsJson));
-                var toolDefs = JsonConvert.DeserializeObject<List<ProxyToolDefinition>>(toolDefsJson);
-                if (toolDefs == null || toolDefs.Count == 0) {
-                    logger.LogWarning("Empty tool definitions from Redis.");
-                    return;
-                }
-
-                var toolExecutor = services.GetRequiredService<Service.ToolExecutor>();
-
-                // Register proxy tools with an executor that routes to the main process via Redis IPC
-                McpToolHelper.RegisterProxyTools(toolDefs, async (toolName, arguments) => {
-                    // Resolve chatId/userId/messageId from ToolContext if needed
-                    // These will be set by the calling code in McpToolHelper before invoking
-                    long remoteChatId = 0, remoteUserId = 0, remoteMessageId = 0;
-                    if (arguments.TryGetValue("__chatId", out var cid)) { long.TryParse(cid, out remoteChatId); arguments.Remove("__chatId"); }
-                    if (arguments.TryGetValue("__userId", out var uid)) { long.TryParse(uid, out remoteUserId); arguments.Remove("__userId"); }
-                    if (arguments.TryGetValue("__messageId", out var mid)) { long.TryParse(mid, out remoteMessageId); arguments.Remove("__messageId"); }
-
-                    logger.LogInformation(
-                        "Proxy tool call routed to main process. Tool={ToolName}, ChatId={ChatId}, UserId={UserId}, MessageId={MessageId}, ArgumentKeys={ArgumentKeys}",
-                        toolName,
-                        remoteChatId,
-                        remoteUserId,
-                        remoteMessageId,
-                        string.Join(",", arguments.Keys));
-                    try {
-                        return await toolExecutor.ExecuteRemoteToolAsync(
-                            toolName, arguments, remoteChatId, remoteUserId, remoteMessageId, CancellationToken.None);
-                    } catch (Exception ex) {
-                        logger.LogError(
-                            ex,
-                            "Proxy tool call failed while routed to main process. Tool={ToolName}, ChatId={ChatId}, UserId={UserId}, MessageId={MessageId}, ErrorSummary={ErrorSummary}",
-                            toolName,
-                            remoteChatId,
-                            remoteUserId,
-                            remoteMessageId,
-                            ex.GetLogSummary());
-                        throw;
-                    }
-                });
-
-                logger.LogInformation(
-                    "Imported {Count} tool definitions from Redis. ToolNames={ToolNames}",
-                    toolDefs.Count,
-                    string.Join(",", toolDefs.Select(t => t.Name).Take(80)));
-            } catch (Exception ex) {
-                logger.LogWarning(ex, "Failed to import tool definitions from Redis. Agent will have limited tools. ErrorSummary={ErrorSummary}", ex.GetLogSummary());
-            }
         }
 
         private static string[] NormalizeArgs(string[] args) {
@@ -137,7 +72,7 @@ namespace TelegramSearchBot.LLMAgent {
             services.AddScoped<OllamaService>();
             services.AddScoped<GeminiService>();
             services.AddScoped<AnthropicService>();
-            services.AddScoped<Service.ToolExecutor>();
+            services.AddSingleton<Service.ToolExecutor>();
             services.AddScoped<Service.AgentToolService>();
             services.AddScoped<IFileToolService, FileToolService>();
             services.AddScoped<IBashToolService, BashToolService>();
@@ -145,6 +80,7 @@ namespace TelegramSearchBot.LLMAgent {
             services.AddScoped<Service.LlmServiceProxy>();
             services.AddSingleton<Service.GarnetClient>();
             services.AddSingleton<Service.GarnetRpcClient>();
+            services.AddSingleton<Service.AgentToolRegistryService>();
             services.AddSingleton<Service.AgentLoopService>();
             return services.BuildServiceProvider();
         }

--- a/TelegramSearchBot.LLMAgent/Service/AgentLoopService.cs
+++ b/TelegramSearchBot.LLMAgent/Service/AgentLoopService.cs
@@ -16,18 +16,21 @@ namespace TelegramSearchBot.LLMAgent.Service {
         private readonly GarnetRpcClient _rpcClient;
         private readonly ILogger<AgentLoopService> _logger;
         private readonly Func<int, TimeSpan> _transientRetryDelayFactory;
+        private readonly AgentToolRegistryService? _toolRegistryService;
 
         public AgentLoopService(
             IServiceProvider serviceProvider,
             GarnetClient garnetClient,
             GarnetRpcClient rpcClient,
             ILogger<AgentLoopService> logger,
-            Func<int, TimeSpan>? transientRetryDelayFactory = null) {
+            Func<int, TimeSpan>? transientRetryDelayFactory = null,
+            AgentToolRegistryService? toolRegistryService = null) {
             _serviceProvider = serviceProvider;
             _garnetClient = garnetClient;
             _rpcClient = rpcClient;
             _logger = logger;
             _transientRetryDelayFactory = transientRetryDelayFactory ?? GetDefaultTransientRetryDelay;
+            _toolRegistryService = toolRegistryService;
         }
 
         public async Task RunAsync(long chatId, int port, CancellationToken cancellationToken) {
@@ -43,6 +46,10 @@ namespace TelegramSearchBot.LLMAgent.Service {
             await _rpcClient.SaveSessionAsync(session);
 
             try {
+                if (_toolRegistryService != null) {
+                    await _toolRegistryService.RefreshUntilAvailableAsync(cancellationToken);
+                }
+
                 while (!cancellationToken.IsCancellationRequested) {
                     if (await IsShutdownRequestedAsync(chatId)) {
                         session.Status = "shutting_down";
@@ -104,6 +111,10 @@ namespace TelegramSearchBot.LLMAgent.Service {
 
                     var shouldStopAfterTask = false;
                     try {
+                        if (_toolRegistryService != null) {
+                            await _toolRegistryService.RefreshAsync(cancellationToken);
+                        }
+
                         _logger.LogInformation(
                             "Agent loop starting task. TaskId={TaskId}, Kind={Kind}, ChatId={ChatId}, UserId={UserId}, MessageId={MessageId}, Model={Model}, RecoveryAttempt={RecoveryAttempt}, RecoveredContentLength={RecoveredContentLength}",
                             task.TaskId,

--- a/TelegramSearchBot.LLMAgent/Service/AgentToolRegistryService.cs
+++ b/TelegramSearchBot.LLMAgent/Service/AgentToolRegistryService.cs
@@ -1,0 +1,129 @@
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using StackExchange.Redis;
+using TelegramSearchBot.Common;
+using TelegramSearchBot.Model.AI;
+using TelegramSearchBot.Service.AI.LLM;
+
+namespace TelegramSearchBot.LLMAgent.Service {
+    public sealed class AgentToolRegistryService {
+        private static readonly TimeSpan StartupWaitTimeout = TimeSpan.FromSeconds(10);
+        private static readonly TimeSpan StartupPollInterval = TimeSpan.FromMilliseconds(250);
+        private readonly IConnectionMultiplexer _redis;
+        private readonly ToolExecutor _toolExecutor;
+        private readonly ILogger<AgentToolRegistryService> _logger;
+        private readonly SemaphoreSlim _refreshLock = new(1, 1);
+        private string _lastDefinitionsJson = string.Empty;
+
+        public AgentToolRegistryService(
+            IConnectionMultiplexer redis,
+            ToolExecutor toolExecutor,
+            ILogger<AgentToolRegistryService> logger) {
+            _redis = redis;
+            _toolExecutor = toolExecutor;
+            _logger = logger;
+        }
+
+        public async Task<bool> RefreshAsync(CancellationToken cancellationToken = default) {
+            try {
+                var json = await _redis.GetDatabase().StringGetAsync(LlmAgentRedisKeys.AgentToolDefs);
+                if (!json.HasValue || string.IsNullOrWhiteSpace(json.ToString())) {
+                    _logger.LogWarning("No tool definitions found in Redis. Agent will have limited tools.");
+                    return false;
+                }
+
+                var toolDefsJson = json.ToString();
+                if (string.Equals(toolDefsJson, _lastDefinitionsJson, StringComparison.Ordinal)) {
+                    return true;
+                }
+
+                await _refreshLock.WaitAsync(cancellationToken);
+                try {
+                    if (string.Equals(toolDefsJson, _lastDefinitionsJson, StringComparison.Ordinal)) {
+                        return true;
+                    }
+
+                    var toolDefs = JsonConvert.DeserializeObject<List<ProxyToolDefinition>>(toolDefsJson);
+                    if (toolDefs == null || toolDefs.Count == 0) {
+                        _logger.LogWarning("Empty tool definitions from Redis.");
+                        return false;
+                    }
+
+                    McpToolHelper.RegisterProxyTools(toolDefs, ExecuteProxyToolAsync);
+                    _lastDefinitionsJson = toolDefsJson;
+
+                    _logger.LogInformation(
+                        "Imported {Count} tool definitions from Redis. ToolNames={ToolNames}",
+                        toolDefs.Count,
+                        string.Join(",", toolDefs.Select(t => t.Name).Take(80)));
+                    return true;
+                } finally {
+                    _refreshLock.Release();
+                }
+            } catch (OperationCanceledException) {
+                throw;
+            } catch (Exception ex) {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to import tool definitions from Redis. Agent will keep its current tools. ErrorSummary={ErrorSummary}",
+                    ex.GetLogSummary());
+                return false;
+            }
+        }
+
+        public async Task RefreshUntilAvailableAsync(CancellationToken cancellationToken = default) {
+            var deadline = DateTime.UtcNow + StartupWaitTimeout;
+            while (!cancellationToken.IsCancellationRequested) {
+                if (await RefreshAsync(cancellationToken)) {
+                    return;
+                }
+
+                if (DateTime.UtcNow >= deadline) {
+                    _logger.LogWarning("Timed out waiting for agent tool definitions in Redis. Agent will start with limited tools.");
+                    return;
+                }
+
+                await Task.Delay(StartupPollInterval, cancellationToken);
+            }
+        }
+
+        private async Task<string> ExecuteProxyToolAsync(string toolName, Dictionary<string, string> arguments) {
+            long remoteChatId = 0, remoteUserId = 0, remoteMessageId = 0;
+            if (arguments.TryGetValue("__chatId", out var cid)) {
+                long.TryParse(cid, out remoteChatId);
+                arguments.Remove("__chatId");
+            }
+            if (arguments.TryGetValue("__userId", out var uid)) {
+                long.TryParse(uid, out remoteUserId);
+                arguments.Remove("__userId");
+            }
+            if (arguments.TryGetValue("__messageId", out var mid)) {
+                long.TryParse(mid, out remoteMessageId);
+                arguments.Remove("__messageId");
+            }
+
+            _logger.LogInformation(
+                "Proxy tool call routed to main process. Tool={ToolName}, ChatId={ChatId}, UserId={UserId}, MessageId={MessageId}, ArgumentKeys={ArgumentKeys}",
+                toolName,
+                remoteChatId,
+                remoteUserId,
+                remoteMessageId,
+                string.Join(",", arguments.Keys));
+
+            try {
+                return await _toolExecutor.ExecuteRemoteToolAsync(
+                    toolName, arguments, remoteChatId, remoteUserId, remoteMessageId, CancellationToken.None);
+            } catch (Exception ex) {
+                _logger.LogError(
+                    ex,
+                    "Proxy tool call failed while routed to main process. Tool={ToolName}, ChatId={ChatId}, UserId={UserId}, MessageId={MessageId}, ErrorSummary={ErrorSummary}",
+                    toolName,
+                    remoteChatId,
+                    remoteUserId,
+                    remoteMessageId,
+                    ex.GetLogSummary());
+                throw;
+            }
+        }
+    }
+}

--- a/TelegramSearchBot/AppBootstrap/AppBootstrap.cs
+++ b/TelegramSearchBot/AppBootstrap/AppBootstrap.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Microsoft.Win32.SafeHandles;
 using Nito.AsyncEx;
 using Serilog;
+using TelegramSearchBot.Common;
 
 namespace TelegramSearchBot.AppBootstrap {
     public class AppBootstrap {
@@ -251,12 +252,24 @@ namespace TelegramSearchBot.AppBootstrap {
 
             process.OutputDataReceived += (_, e) => {
                 if (!string.IsNullOrWhiteSpace(e.Data)) {
-                    Log.Logger.Information("[{Process}] {Message}", processDisplayName, e.Data);
+                    if (ShouldRouteChildOutputToChatContentLog(processDisplayName)) {
+                        using (LoggerHolders.PushChatContentLogScope()) {
+                            Log.Logger.Information("[{Process}] {Message}", processDisplayName, e.Data);
+                        }
+                    } else {
+                        Log.Logger.Information("[{Process}] {Message}", processDisplayName, e.Data);
+                    }
                 }
             };
             process.ErrorDataReceived += (_, e) => {
                 if (!string.IsNullOrWhiteSpace(e.Data)) {
-                    Log.Logger.Warning("[{Process}] {Message}", processDisplayName, e.Data);
+                    if (ShouldRouteChildOutputToChatContentLog(processDisplayName)) {
+                        using (LoggerHolders.PushChatContentLogScope()) {
+                            Log.Logger.Warning("[{Process}] {Message}", processDisplayName, e.Data);
+                        }
+                    } else {
+                        Log.Logger.Warning("[{Process}] {Message}", processDisplayName, e.Data);
+                    }
                 }
             };
             process.Exited += (_, _) => {
@@ -276,6 +289,11 @@ namespace TelegramSearchBot.AppBootstrap {
             childProcessManager.AddProcess(process, processMemoryLimitBytes);
             Log.Logger.Information("{Process}已启动", processDisplayName);
             return process;
+        }
+
+        private static bool ShouldRouteChildOutputToChatContentLog(string processDisplayName) {
+            return processDisplayName.Contains("LLMAgent", StringComparison.OrdinalIgnoreCase) ||
+                   processDisplayName.Contains("SubAgent", StringComparison.OrdinalIgnoreCase);
         }
 
         /// <summary>

--- a/TelegramSearchBot/AppBootstrap/QRBootstrap.cs
+++ b/TelegramSearchBot/AppBootstrap/QRBootstrap.cs
@@ -8,6 +8,7 @@ using Microsoft.EntityFrameworkCore.Internal;
 using Microsoft.Extensions.Logging;
 using Serilog;
 using StackExchange.Redis;
+using TelegramSearchBot.Common;
 using TelegramSearchBot.Manager;
 
 namespace TelegramSearchBot.AppBootstrap {
@@ -37,7 +38,9 @@ namespace TelegramSearchBot.AppBootstrap {
                 Log.Logger.Information("QR processing started: task={task}, path={path}", task, photoPath);
                 try {
                     response = await qr.ExecuteAsync(photoPath);
-                    Log.Logger.Information("QR result: task={task}, len={len}, content={preview}", task, response?.Length ?? -1, response?.Length > 100 ? response.Substring(0, 100) + "..." : response);
+                    using (LoggerHolders.PushChatContentLogScope()) {
+                        Log.Logger.Information("QR result: task={task}, len={len}, content={preview}", task, response?.Length ?? -1, response?.Length > 100 ? response.Substring(0, 100) + "..." : response);
+                    }
                 } catch (Exception ex) {
                     Log.Logger.Warning(ex, "QR processing failed for task {task}", task);
                 }

--- a/TelegramSearchBot/Controller/AI/ASR/AutoASRController.cs
+++ b/TelegramSearchBot/Controller/AI/ASR/AutoASRController.cs
@@ -82,7 +82,9 @@ namespace TelegramSearchBot.Controller.AI.ASR {
                 //logger.LogInformation($"Get Audio File: {e.Message.Chat.Id}/{e.Message.MessageId}");
                 var path = GetFilePath(e);
                 var AsrStr = await autoASRService.ExecuteAsync(path);
-                logger.LogInformation(AsrStr);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    logger.LogInformation(AsrStr);
+                }
                 await MessageExtensionService.AddOrUpdateAsync(p.MessageDataId, "ASR_Result", AsrStr);
                 if (AsrStr.Length > 4095) {
                     await SendMessageService.SendDocument(AsrStr, $"{e.Message.MessageId}.srt", e.Message.Chat.Id, e.Message.MessageId);

--- a/TelegramSearchBot/Controller/AI/LLM/AltPhotoController.cs
+++ b/TelegramSearchBot/Controller/AI/LLM/AltPhotoController.cs
@@ -61,7 +61,9 @@ namespace TelegramSearchBot.Controller.AI.LLM {
                 var PhotoPath = IProcessPhoto.GetPhotoPath(e);
                 logger.LogInformation($"Get Photo File: {e.Message.Chat.Id}/{e.Message.MessageId}");
                 OcrStr = await generalLLMService.AnalyzeImageAsync(PhotoPath, e.Message.Chat.Id);
-                logger.LogInformation(OcrStr);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    logger.LogInformation(OcrStr);
+                }
                 if (!OcrStr.StartsWith("Error")) {
                     await MessageExtensionService.AddOrUpdateAsync(p.MessageDataId, "Alt_Result", OcrStr);
                 }

--- a/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
+++ b/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
@@ -93,7 +93,9 @@ namespace TelegramSearchBot.Controller.AI.LLM {
                     string commandText = Message.Substring(botCommandEntity.Offset, botCommandEntity.Length);
                     // Check if the command text itself contains @BotName (e.g., /cmd@MyBot)
                     if (commandText.Contains($"@{botIdentity.UserName}")) {
-                        logger.LogInformation($"Ignoring command '{commandText}' in GeneralLLMController as it's a direct command to the bot and should be handled by a dedicated command handler. MessageId: {telegramMessage.MessageId}");
+                        using (LoggerHolders.PushChatContentLogScope()) {
+                            logger.LogInformation($"Ignoring command '{commandText}' in GeneralLLMController as it's a direct command to the bot and should be handled by a dedicated command handler. MessageId: {telegramMessage.MessageId}");
+                        }
                         return; // Let other command handlers process it
                     }
                 }

--- a/TelegramSearchBot/Controller/AI/OCR/AutoOCRController.cs
+++ b/TelegramSearchBot/Controller/AI/OCR/AutoOCRController.cs
@@ -78,7 +78,9 @@ namespace TelegramSearchBot.Controller.AI.OCR {
                 logger.LogInformation($"使用OCR引擎: {engine}");
                 OcrStr = await ocrService.ExecuteAsync(new MemoryStream(PhotoStream));
                 if (!string.IsNullOrWhiteSpace(OcrStr)) {
-                    logger.LogInformation(OcrStr);
+                    using (LoggerHolders.PushChatContentLogScope()) {
+                        logger.LogInformation(OcrStr);
+                    }
                     await MessageExtensionService.AddOrUpdateAsync(p.MessageDataId, "OCR_Result", OcrStr);
                     p.ProcessingResults.Add($"[OCR识别结果] {OcrStr}");
                 }

--- a/TelegramSearchBot/Controller/AI/QR/AutoQRController.cs
+++ b/TelegramSearchBot/Controller/AI/QR/AutoQRController.cs
@@ -20,6 +20,7 @@ using TelegramSearchBot.Model; // Added for MessageOption
 using TelegramSearchBot.Model.Notifications; // Added for TextMessageReceivedNotification
 using TelegramSearchBot.Service.AI.QR; // Added for AutoQRService
 using TelegramSearchBot.Service.BotAPI;
+using TelegramSearchBot.Common;
 using TelegramSearchBot.Service.Common;
 using TelegramSearchBot.Service.Storage; // Added for MessageService
 
@@ -75,8 +76,10 @@ namespace TelegramSearchBot.Controller.AI.QR {
                     return;
                 }
 
-                _logger.LogInformation("QR Code recognized for {ChatId}/{MessageId}. Content: {QrStr}, Length: {QrStrLen}",
-                    e.Message.Chat.Id, e.Message.MessageId, qrStr, qrStr.Length);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogInformation("QR Code recognized for {ChatId}/{MessageId}. Content: {QrStr}, Length: {QrStrLen}",
+                        e.Message.Chat.Id, e.Message.MessageId, qrStr, qrStr.Length);
+                }
 
                 // Add QR result to processing results
                 p.ProcessingResults.Add($"[QR识别结果] {qrStr}");

--- a/TelegramSearchBot/Controller/Bilibili/BiliMessageController.cs
+++ b/TelegramSearchBot/Controller/Bilibili/BiliMessageController.cs
@@ -10,6 +10,7 @@ using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
 using TelegramSearchBot.Controller.AI.OCR;
 using TelegramSearchBot.Controller.AI.QR;
+using TelegramSearchBot.Common;
 using TelegramSearchBot.Helper;
 using TelegramSearchBot.Interface.Bilibili;
 using TelegramSearchBot.Interface.Controller;
@@ -97,36 +98,52 @@ namespace TelegramSearchBot.Controller.Bilibili { // Namespace open
                     } else if (BiliOpusUrlPattern.IsMatch(url)) {
                         await ProcessOpusUrlAsync(message, url);
                     } else {
-                        _logger.LogWarning("URL {Url} matched general Bili regex but not specific patterns. Attempting video parse first.", url);
+                        using (LoggerHolders.PushChatContentLogScope()) {
+                            _logger.LogWarning("URL {Url} matched general Bili regex but not specific patterns. Attempting video parse first.", url);
+                        }
                         var videoInfo = await _biliApiService.GetVideoInfoAsync(url);
                         if (videoInfo != null) await HandleVideoInfoAsync(message, videoInfo);
                         else {
                             var opusInfo = await _biliApiService.GetOpusInfoAsync(url);
                             if (opusInfo != null) await HandleOpusInfoAsync(message, opusInfo);
-                            else _logger.LogWarning("Could not parse Bilibili URL: {Url} as either video or opus.", url);
+                            else {
+                                using (LoggerHolders.PushChatContentLogScope()) {
+                                    _logger.LogWarning("Could not parse Bilibili URL: {Url} as either video or opus.", url);
+                                }
+                            }
                         }
                     }
                 } catch (Exception ex) {
-                    _logger.LogError(ex, "Error processing Bilibili URL: {Url}", url);
+                    using (LoggerHolders.PushChatContentLogScope()) {
+                        _logger.LogError(ex, "Error processing Bilibili URL: {Url}", url);
+                    }
                 }
             }
         }
 
         private async Task ProcessVideoUrlAsync(Message message, string url) {
-            _logger.LogInformation("Processing Bilibili video URL: {Url}", url);
+            using (LoggerHolders.PushChatContentLogScope()) {
+                _logger.LogInformation("Processing Bilibili video URL: {Url}", url);
+            }
             var videoInfo = await _biliApiService.GetVideoInfoAsync(url);
             if (videoInfo == null) {
-                _logger.LogWarning("Failed to get video info for {Url}", url);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogWarning("Failed to get video info for {Url}", url);
+                }
                 return;
             }
             await HandleVideoInfoAsync(message, videoInfo);
         }
 
         private async Task ProcessOpusUrlAsync(Message message, string url) {
-            _logger.LogInformation("Processing Bilibili opus URL: {Url}", url);
+            using (LoggerHolders.PushChatContentLogScope()) {
+                _logger.LogInformation("Processing Bilibili opus URL: {Url}", url);
+            }
             var opusInfo = await _biliApiService.GetOpusInfoAsync(url);
             if (opusInfo == null) {
-                _logger.LogWarning("Failed to get opus info for {Url}", url);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogWarning("Failed to get opus info for {Url}", url);
+                }
                 return;
             }
             await HandleOpusInfoAsync(message, opusInfo);

--- a/TelegramSearchBot/Manager/SendMessage.cs
+++ b/TelegramSearchBot/Manager/SendMessage.cs
@@ -29,7 +29,9 @@ namespace TelegramSearchBot.Manager {
             this.logger = logger;
         }
         public async Task Log(string Text) {
-            logger.LogInformation(Text);
+            using (LoggerHolders.PushChatContentLogScope()) {
+                logger.LogInformation(Text);
+            }
             await AddTask(async () => {
                 await botClient.SendMessage(
                     chatId: Env.AdminId,

--- a/TelegramSearchBot/Manager/WhisperManager.cs
+++ b/TelegramSearchBot/Manager/WhisperManager.cs
@@ -83,7 +83,9 @@ namespace TelegramSearchBot.Manager {
             try {
                 await foreach (var result in processor.ProcessAsync(wavStream, token)) {
                     timeTaken = DateTime.UtcNow - startTime;
-                    logger.LogInformation($"{result.Start.ToLongString()}-->{result.End.ToLongString()}: {result.Text,-150} [{timeTaken.ToLongString()}]");
+                    using (LoggerHolders.PushChatContentLogScope()) {
+                        logger.LogInformation($"{result.Start.ToLongString()}-->{result.End.ToLongString()}: {result.Text,-150} [{timeTaken.ToLongString()}]");
+                    }
                     ToReturn.Add($"{startId}");
                     ToReturn.Add($"{result.Start.ToString(@"hh\:mm\:ss\,fff")} --> {result.End.ToString(@"hh\:mm\:ss\,fff")}");
                     ToReturn.Add($"{result.Text}\n");

--- a/TelegramSearchBot/Program.cs
+++ b/TelegramSearchBot/Program.cs
@@ -23,23 +23,32 @@ namespace TelegramSearchBot {
             Log.Logger = new LoggerConfiguration()
             .MinimumLevel.Is(Env.SerilogMinimumLevel) // 默认打开完整日志，便于追踪 LLM/Agent 级异常
             .MinimumLevel.Override("Microsoft.EntityFrameworkCore.Database.Command", Serilog.Events.LogEventLevel.Debug) // SQL 语句只在 Debug 级别输出
-            .WriteTo.Console(
-                restrictedToMinimumLevel: Env.SerilogMinimumLevel,
-                outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
-            .WriteTo.File($"{Env.WorkDir}/logs/log-.txt",
-              restrictedToMinimumLevel: Env.SerilogMinimumLevel,
-              rollingInterval: RollingInterval.Day,
-              outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
-            .WriteTo.OpenTelemetry(
-                endpoint: Env.OLTPAuthUrl,
-                protocol: OtlpProtocol.HttpProtobuf,
-                headers: new Dictionary<string, string>() {
-                    { "Authorization", $"Basic {Env.OLTPAuth}" },
-                    { "stream-name", Env.OLTPName }
-                },
-                resourceAttributes: null,
-                includedData: null,
-                restrictedToMinimumLevel: Env.SerilogMinimumLevel)
+            .Enrich.FromLogContext()
+            .WriteTo.Logger(logger => logger
+                .Filter.ByExcluding(LoggerHolders.IsChatContentLogEvent)
+                .WriteTo.Console(
+                    restrictedToMinimumLevel: Env.SerilogMinimumLevel,
+                    outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .WriteTo.File($"{Env.WorkDir}/logs/log-.txt",
+                  restrictedToMinimumLevel: Env.SerilogMinimumLevel,
+                  rollingInterval: RollingInterval.Day,
+                  outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .WriteTo.OpenTelemetry(
+                    endpoint: Env.OLTPAuthUrl,
+                    protocol: OtlpProtocol.HttpProtobuf,
+                    headers: new Dictionary<string, string>() {
+                        { "Authorization", $"Basic {Env.OLTPAuth}" },
+                        { "stream-name", Env.OLTPName }
+                    },
+                    resourceAttributes: null,
+                    includedData: null,
+                    restrictedToMinimumLevel: Env.SerilogMinimumLevel))
+            .WriteTo.Logger(logger => logger
+                .Filter.ByIncludingOnly(LoggerHolders.IsChatContentLogEvent)
+                .WriteTo.File($"{Env.WorkDir}/logs/chat-content-.txt",
+                  restrictedToMinimumLevel: Env.SerilogMinimumLevel,
+                  rollingInterval: RollingInterval.Day,
+                  outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"))
             .CreateLogger();
             AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
             if (args.Length == 0) {

--- a/TelegramSearchBot/Service/AI/LLM/ChunkPollingService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/ChunkPollingService.cs
@@ -123,18 +123,22 @@ namespace TelegramSearchBot.Service.AI.LLM {
                     tracked.Completion.TrySetResult(terminal);
                     tracked.Channel.Writer.TryComplete();
                     _trackedTasks.TryRemove(taskId, out _);
-                    _logger.LogInformation(
-                        "ChunkPollingService: task completed from terminal chunk. TaskId={TaskId}, TerminalType={TerminalType}, Error={Error}",
-                        taskId,
-                        terminal.Type,
-                        terminal.ErrorMessage);
+                    using (LoggerHolders.PushChatContentLogScope()) {
+                        _logger.LogInformation(
+                            "ChunkPollingService: task completed from terminal chunk. TaskId={TaskId}, TerminalType={TerminalType}, Error={Error}",
+                            taskId,
+                            terminal.Type,
+                            terminal.ErrorMessage);
+                    }
                     // Cleanup keys (use TTL as safety net, no race condition)
                     _ = db.KeyDeleteAsync(LlmAgentRedisKeys.AgentSnapshot(taskId));
                     _ = db.KeyDeleteAsync(LlmAgentRedisKeys.AgentTerminal(taskId));
                     return;
                 }
 
-                _logger.LogWarning("ChunkPollingService: terminal chunk payload could not be deserialized. TaskId={TaskId}, PayloadPreview={PayloadPreview}", taskId, TruncateForLog(terminalPayload));
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogWarning("ChunkPollingService: terminal chunk payload could not be deserialized. TaskId={TaskId}, PayloadPreview={PayloadPreview}", taskId, TruncateForLog(terminalPayload));
+                }
             }
 
             // Check for snapshot updates
@@ -161,7 +165,9 @@ namespace TelegramSearchBot.Service.AI.LLM {
                     chunk.Sequence,
                     chunk.Content?.Length ?? 0);
             } else if (chunk == null) {
-                _logger.LogWarning("ChunkPollingService: snapshot payload could not be deserialized. TaskId={TaskId}, PayloadPreview={PayloadPreview}", taskId, TruncateForLog(snapshotStr));
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogWarning("ChunkPollingService: snapshot payload could not be deserialized. TaskId={TaskId}, PayloadPreview={PayloadPreview}", taskId, TruncateForLog(snapshotStr));
+                }
             }
         }
 
@@ -185,11 +191,13 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
             if (status == AgentTaskStatus.Failed || status == AgentTaskStatus.Cancelled) {
                 var error = entries.FirstOrDefault(x => x.Name == "error").Value.ToString();
-                _logger.LogWarning(
-                    "ChunkPollingService: completing task from failed task state. TaskId={TaskId}, Status={Status}, Error={Error}",
-                    taskId,
-                    status,
-                    error);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogWarning(
+                        "ChunkPollingService: completing task from failed task state. TaskId={TaskId}, Status={Status}, Error={Error}",
+                        taskId,
+                        status,
+                        error);
+                }
                 await CompleteTrackedTaskAsync(taskId, tracked, new AgentStreamChunk {
                     TaskId = taskId,
                     Type = AgentChunkType.Error,
@@ -255,7 +263,9 @@ namespace TelegramSearchBot.Service.AI.LLM {
                         snapshot.Sequence,
                         snapshot.Content.Length);
                 } else if (snapshot == null) {
-                    _logger.LogWarning("ChunkPollingService: final snapshot payload could not be deserialized. TaskId={TaskId}, PayloadPreview={PayloadPreview}", taskId, TruncateForLog(snapshotPayload));
+                    using (LoggerHolders.PushChatContentLogScope()) {
+                        _logger.LogWarning("ChunkPollingService: final snapshot payload could not be deserialized. TaskId={TaskId}, PayloadPreview={PayloadPreview}", taskId, TruncateForLog(snapshotPayload));
+                    }
                 }
             } catch (Exception ex) {
                 _logger.LogWarning(ex, "ChunkPollingService: failed to deliver final snapshot for task {TaskId}", taskId);

--- a/TelegramSearchBot/Service/BotAPI/SendMessageService.Streaming.cs
+++ b/TelegramSearchBot/Service/BotAPI/SendMessageService.Streaming.cs
@@ -10,6 +10,7 @@ using Telegram.Bot;
 using Telegram.Bot.Exceptions;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
+using TelegramSearchBot.Common;
 using TelegramSearchBot.Helper;
 using TelegramSearchBot.Model;
 
@@ -390,12 +391,14 @@ namespace TelegramSearchBot.Service.BotAPI {
                         _draftUnsupportedChats.TryAdd(chatId, true);
                         logger.LogInformation("SendDraftStream: Chat {ChatId} does not support draft messages. Will use SendFullMessageStream for future requests.", chatId);
                     } else {
-                        logger.LogWarning(ex,
-                            "SendDraftStream: Failed to send initial draft placeholder. ChatId {ChatId}, DraftId {DraftId}, PlaceholderLength {PlaceholderLength}, PlaceholderPreview {PlaceholderPreview}. Falling back to SendFullMessageStream.",
-                            chatId,
-                            draftId,
-                            initialPlaceholderContent?.Length ?? 0,
-                            GetContentPreview(initialPlaceholderContent));
+                        using (LoggerHolders.PushChatContentLogScope()) {
+                            logger.LogWarning(ex,
+                                "SendDraftStream: Failed to send initial draft placeholder. ChatId {ChatId}, DraftId {DraftId}, PlaceholderLength {PlaceholderLength}, PlaceholderPreview {PlaceholderPreview}. Falling back to SendFullMessageStream.",
+                                chatId,
+                                draftId,
+                                initialPlaceholderContent?.Length ?? 0,
+                                GetContentPreview(initialPlaceholderContent));
+                        }
                     }
                     // Fall back to the old method if sendMessageDraft is not supported
                     return await SendFullMessageStream(fullMessagesStream, chatId, replyTo, initialPlaceholderContent, cancellationToken);
@@ -414,20 +417,24 @@ namespace TelegramSearchBot.Service.BotAPI {
                         if (!string.IsNullOrWhiteSpace(html)) {
                             await botClient.SendMessageDraft(chatId, draftId, html, parseMode: ParseMode.Html, cancellationToken: cancellationToken);
                         } else if (!string.IsNullOrWhiteSpace(displayMarkdown)) {
-                            logger.LogDebug(
-                                "SendDraftStream: Markdown collapsed to empty HTML. ChatId {ChatId}, DraftId {DraftId}, MarkdownLength {MarkdownLength}, MarkdownPreview {MarkdownPreview}.",
-                                chatId,
-                                draftId,
-                                displayMarkdown.Length,
-                                GetContentPreview(displayMarkdown));
+                            using (LoggerHolders.PushChatContentLogScope()) {
+                                logger.LogDebug(
+                                    "SendDraftStream: Markdown collapsed to empty HTML. ChatId {ChatId}, DraftId {DraftId}, MarkdownLength {MarkdownLength}, MarkdownPreview {MarkdownPreview}.",
+                                    chatId,
+                                    draftId,
+                                    displayMarkdown.Length,
+                                    GetContentPreview(displayMarkdown));
+                            }
                         }
                     } catch (Exception ex) {
-                        logger.LogWarning(ex,
-                            "SendDraftStream: Error sending draft update. ChatId {ChatId}, DraftId {DraftId}, MarkdownLength {MarkdownLength}, MarkdownPreview {MarkdownPreview}.",
-                            chatId,
-                            draftId,
-                            latestContent?.Length ?? 0,
-                            GetContentPreview(latestContent));
+                        using (LoggerHolders.PushChatContentLogScope()) {
+                            logger.LogWarning(ex,
+                                "SendDraftStream: Error sending draft update. ChatId {ChatId}, DraftId {DraftId}, MarkdownLength {MarkdownLength}, MarkdownPreview {MarkdownPreview}.",
+                                chatId,
+                                draftId,
+                                latestContent?.Length ?? 0,
+                                GetContentPreview(latestContent));
+                        }
                     }
                 }
             } catch (OperationCanceledException) {
@@ -445,12 +452,14 @@ namespace TelegramSearchBot.Service.BotAPI {
                         await botClient.SendMessageDraft(chatId, draftId, finalHtml, parseMode: ParseMode.Html, cancellationToken: CancellationToken.None);
                     }
                 } catch (Exception ex) {
-                    logger.LogWarning(ex,
-                        "SendDraftStream: Error sending final draft content. ChatId {ChatId}, DraftId {DraftId}, MarkdownLength {MarkdownLength}, MarkdownPreview {MarkdownPreview}.",
-                        chatId,
-                        draftId,
-                        latestContent.Length,
-                        GetContentPreview(latestContent));
+                    using (LoggerHolders.PushChatContentLogScope()) {
+                        logger.LogWarning(ex,
+                            "SendDraftStream: Error sending final draft content. ChatId {ChatId}, DraftId {DraftId}, MarkdownLength {MarkdownLength}, MarkdownPreview {MarkdownPreview}.",
+                            chatId,
+                            draftId,
+                            latestContent.Length,
+                            GetContentPreview(latestContent));
+                    }
                 }
             }
 

--- a/TelegramSearchBot/Service/Common/UrlProcessingService.cs
+++ b/TelegramSearchBot/Service/Common/UrlProcessingService.cs
@@ -8,6 +8,7 @@ using System.Web; // For HttpUtility. NuGet: System.Web.HttpUtility if not avail
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging; // Added for ILogger
 using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Common;
 using TelegramSearchBot.Interface;
 
 namespace TelegramSearchBot.Service.Common {
@@ -76,6 +77,8 @@ namespace TelegramSearchBot.Service.Common {
         }
 
         private async Task<string?> GetFinalRedirectedUrlAsync(string originalUrl) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
+
             if (!Uri.TryCreate(originalUrl, UriKind.Absolute, out var uri)) {
                 _logger.LogWarning("Invalid URL format: {OriginalUrl}", originalUrl);
                 return null;

--- a/TelegramSearchBot/Service/Common/UrlProcessingService.cs
+++ b/TelegramSearchBot/Service/Common/UrlProcessingService.cs
@@ -141,6 +141,8 @@ namespace TelegramSearchBot.Service.Common {
         }
 
         private string? CleanUrlOfTrackingParameters(string? url) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
+
             if (string.IsNullOrWhiteSpace(url)) {
                 return url;
             }
@@ -173,6 +175,8 @@ namespace TelegramSearchBot.Service.Common {
         }
 
         public async Task<string?> ProcessUrlAsync(string originalUrl) {
+            using var chatContentLogScope = LoggerHolders.PushChatContentLogScope();
+
             string? finalUrl = await GetFinalRedirectedUrlAsync(originalUrl).ConfigureAwait(false);
 
             if (finalUrl == null) {

--- a/TelegramSearchBot/Service/Storage/MessageService.cs
+++ b/TelegramSearchBot/Service/Storage/MessageService.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Nito.AsyncEx;
 using Telegram.Bot.Types.Enums;
 using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Common;
 using TelegramSearchBot.Helper;
 using TelegramSearchBot.Interface;
 using TelegramSearchBot.Manager;
@@ -130,7 +131,9 @@ namespace TelegramSearchBot.Service.Storage {
         }
 
         public async Task<long> ExecuteAsync(MessageOption messageOption) {
-            Logger.LogInformation($"UserId: {messageOption.UserId}\nUserName: {messageOption.User.Username} {messageOption.User.FirstName} {messageOption.User.LastName}\nChatId: {messageOption.ChatId}\nChatName: {messageOption.Chat.Username}\nMessage: {messageOption.MessageId} {messageOption.Content}");
+            using (LoggerHolders.PushChatContentLogScope()) {
+                Logger.LogInformation($"UserId: {messageOption.UserId}\nUserName: {messageOption.User.Username} {messageOption.User.FirstName} {messageOption.User.LastName}\nChatId: {messageOption.ChatId}\nChatName: {messageOption.Chat.Username}\nMessage: {messageOption.MessageId} {messageOption.Content}");
+            }
             using (await _asyncLock.LockAsync()) {
                 return await AddToSqlite(messageOption);
             }

--- a/TelegramSearchBot/Service/Tools/MemoryService.cs
+++ b/TelegramSearchBot/Service/Tools/MemoryService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Common;
 using TelegramSearchBot.Interface;
 using TelegramSearchBot.Interface.Tools;
 using TelegramSearchBot.Model;
@@ -225,8 +226,10 @@ For delete_relations: {relations: [{from: string, to: string, relationType: stri
 ")] string arguments,
             ToolContext toolContext) {
             try {
-                _logger.LogDebug("ProcessMemoryCommandAsync called with command: {Command}, arguments: {Arguments}, chatId: {ChatId}",
-                    command, arguments, toolContext.ChatId);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogDebug("ProcessMemoryCommandAsync called with command: {Command}, arguments: {Arguments}, chatId: {ChatId}",
+                        command, arguments, toolContext.ChatId);
+                }
 
                 switch (command.ToLower()) {
                     case "create_entities":
@@ -265,14 +268,20 @@ For delete_relations: {relations: [{from: string, to: string, relationType: stri
                         throw new ArgumentException($"Unknown command: {command}");
                 }
             } catch (JsonException ex) {
-                _logger.LogError(ex, "JSON deserialization failed for command: {Command}, arguments: {Arguments}", command, arguments);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogError(ex, "JSON deserialization failed for command: {Command}, arguments: {Arguments}", command, arguments);
+                }
                 throw new Exception($"Memory command failed - Invalid JSON format: {ex.Message}", ex);
             } catch (ArgumentException ex) {
-                _logger.LogError(ex, "Invalid argument for command: {Command}, arguments: {Arguments}", command, arguments);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogError(ex, "Invalid argument for command: {Command}, arguments: {Arguments}", command, arguments);
+                }
                 throw new Exception($"Memory command failed - {ex.Message}", ex);
             } catch (Exception ex) {
-                _logger.LogError(ex, "Memory command failed for command: {Command}, arguments: {Arguments}, chatId: {ChatId}",
-                    command, arguments, toolContext.ChatId);
+                using (LoggerHolders.PushChatContentLogScope()) {
+                    _logger.LogError(ex, "Memory command failed for command: {Command}, arguments: {Arguments}, chatId: {ChatId}",
+                        command, arguments, toolContext.ChatId);
+                }
                 throw new Exception($"Memory command failed: {ex.Message}", ex);
             }
         }


### PR DESCRIPTION
## Summary
- add an agent-side tool registry refresher that imports proxy tool definitions from Redis after the agent heartbeat is visible
- refresh proxy tool definitions before each agent task so long-lived agents pick up newly exported built-in/MCP tools
- keep exported agent tool definitions persistent in Redis instead of expiring after 24 hours

## Tests
- dotnet test TelegramSearchBot.LLM.Test\TelegramSearchBot.LLM.Test.csproj --configuration Release --no-restore
- dotnet test TelegramSearchBot.Test\TelegramSearchBot.Test.csproj --configuration Release --no-restore --filter "FullyQualifiedName~Agent"
- dotnet build TelegramSearchBot.sln --configuration Release --no-restore -m:1
