### PR TITLE
Add LLM invisibility for group users

### DIFF
--- a/TelegramSearchBot.Database/Migrations/20260601111353_AddLlmInvisibilityToUserWithGroup.Designer.cs
+++ b/TelegramSearchBot.Database/Migrations/20260601111353_AddLlmInvisibilityToUserWithGroup.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TelegramSearchBot.Model;
 
@@ -10,9 +11,11 @@ using TelegramSearchBot.Model;
 namespace TelegramSearchBot.Migrations
 {
     [DbContext(typeof(DataDbContext))]
-    partial class DataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260601111353_AddLlmInvisibilityToUserWithGroup")]
+    partial class AddLlmInvisibilityToUserWithGroup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/TelegramSearchBot.Database/Migrations/20260601111353_AddLlmInvisibilityToUserWithGroup.cs
+++ b/TelegramSearchBot.Database/Migrations/20260601111353_AddLlmInvisibilityToUserWithGroup.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelegramSearchBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLlmInvisibilityToUserWithGroup : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsLlmInvisible",
+                table: "UsersWithGroup",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsLlmInvisible",
+                table: "UsersWithGroup");
+        }
+    }
+}

--- a/TelegramSearchBot.Database/Migrations/20260601113631_AddLlmInvisibilityLookupIndex.Designer.cs
+++ b/TelegramSearchBot.Database/Migrations/20260601113631_AddLlmInvisibilityLookupIndex.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using TelegramSearchBot.Model;
 
@@ -10,9 +11,11 @@ using TelegramSearchBot.Model;
 namespace TelegramSearchBot.Migrations
 {
     [DbContext(typeof(DataDbContext))]
-    partial class DataDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260601113631_AddLlmInvisibilityLookupIndex")]
+    partial class AddLlmInvisibilityLookupIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.7");

--- a/TelegramSearchBot.Database/Migrations/20260601113631_AddLlmInvisibilityLookupIndex.cs
+++ b/TelegramSearchBot.Database/Migrations/20260601113631_AddLlmInvisibilityLookupIndex.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TelegramSearchBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLlmInvisibilityLookupIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "IX_UsersWithGroup_GroupId_IsLlmInvisible",
+                table: "UsersWithGroup",
+                columns: new[] { "GroupId", "IsLlmInvisible" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_UsersWithGroup_GroupId_IsLlmInvisible",
+                table: "UsersWithGroup");
+        }
+    }
+}

--- a/TelegramSearchBot.Database/Model/Data/UserWithGroup.cs
+++ b/TelegramSearchBot.Database/Model/Data/UserWithGroup.cs
@@ -11,5 +11,6 @@ namespace TelegramSearchBot.Model.Data {
         public long Id { get; set; }
         public long GroupId { get; set; }
         public long UserId { get; set; }
+        public bool IsLlmInvisible { get; set; }
     }
 }

--- a/TelegramSearchBot.Database/Model/DataDbContext.cs
+++ b/TelegramSearchBot.Database/Model/DataDbContext.cs
@@ -36,6 +36,9 @@ namespace TelegramSearchBot.Model {
                 .HasIndex(uwg => new { uwg.UserId, uwg.GroupId })
                 .IsUnique();
 
+            modelBuilder.Entity<UserWithGroup>()
+                .HasIndex(uwg => new { uwg.GroupId, uwg.IsLlmInvisible });
+
             // 配置对话段模型
             modelBuilder.Entity<ConversationSegment>()
                 .HasIndex(cs => new { cs.GroupId, cs.StartTime, cs.EndTime });

--- a/TelegramSearchBot.LLM.Test/Service/AI/LLM/LlmVisibilityServiceTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/AI/LLM/LlmVisibilityServiceTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Model.Data;
+using TelegramSearchBot.Service.AI.LLM;
+using Xunit;
+
+namespace TelegramSearchBot.LLM.Test.Service.AI.LLM {
+    public class LlmVisibilityServiceTests {
+        [Fact]
+        public async Task SetUserInvisibleAsync_UpdatesGroupScopedState() {
+            await using var dbContext = CreateDbContext();
+            var service = new LlmVisibilityService(dbContext);
+
+            var enabled = await service.SetUserInvisibleAsync(-1001, 42, true);
+            var isInvisible = await service.IsUserInvisibleAsync(-1001, 42);
+            var isInvisibleInOtherGroup = await service.IsUserInvisibleAsync(-1002, 42);
+
+            Assert.True(enabled);
+            Assert.True(isInvisible);
+            Assert.False(isInvisibleInOtherGroup);
+
+            var disabled = await service.SetUserInvisibleAsync(-1001, 42, false);
+
+            Assert.False(disabled);
+            Assert.False(await service.IsUserInvisibleAsync(-1001, 42));
+        }
+
+        [Fact]
+        public async Task FilterVisibleMessagesAsync_RemovesInvisibleUsersMessages() {
+            await using var dbContext = CreateDbContext();
+            dbContext.UsersWithGroup.Add(new UserWithGroup {
+                GroupId = -1001,
+                UserId = 42,
+                IsLlmInvisible = true
+            });
+            await dbContext.SaveChangesAsync();
+
+            var service = new LlmVisibilityService(dbContext);
+            var messages = new List<Message> {
+                new() { GroupId = -1001, FromUserId = 10, Content = "visible" },
+                new() { GroupId = -1001, FromUserId = 42, Content = "hidden" },
+                new() { GroupId = -1001, FromUserId = 11, Content = "also visible" }
+            };
+
+            var filtered = await service.FilterVisibleMessagesAsync(-1001, messages);
+
+            Assert.Equal(new long[] { 10, 11 }, filtered.Select(x => x.FromUserId).ToArray());
+            Assert.DoesNotContain(filtered, x => x.Content == "hidden");
+        }
+
+        private static DataDbContext CreateDbContext() {
+            var options = new DbContextOptionsBuilder<DataDbContext>()
+                .UseInMemoryDatabase($"LlmVisibilityServiceTests_{Guid.NewGuid():N}")
+                .Options;
+            return new DataDbContext(options);
+        }
+    }
+}

--- a/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/AnthropicService.cs
@@ -33,6 +33,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly IMessageExtensionService _messageExtensionService;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IBotIdentityProvider _botIdentityProvider;
+        private readonly LlmVisibilityService _llmVisibilityService;
         private string _fallbackBotName = string.Empty;
 
         public string BotName {
@@ -61,7 +62,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             ILogger<AnthropicService> logger,
             IMessageExtensionService messageExtensionService,
             IHttpClientFactory httpClientFactory)
-            : this(context, logger, messageExtensionService, httpClientFactory, null) {
+            : this(context, logger, messageExtensionService, httpClientFactory, null, null) {
         }
 
         public AnthropicService(
@@ -69,12 +70,14 @@ namespace TelegramSearchBot.Service.AI.LLM {
             ILogger<AnthropicService> logger,
             IMessageExtensionService messageExtensionService,
             IHttpClientFactory httpClientFactory,
-            IBotIdentityProvider botIdentityProvider) {
+            IBotIdentityProvider botIdentityProvider,
+            LlmVisibilityService llmVisibilityService = null) {
             _logger = logger;
             _dbContext = context;
             _messageExtensionService = messageExtensionService;
             _httpClientFactory = httpClientFactory;
             _botIdentityProvider = botIdentityProvider;
+            _llmVisibilityService = llmVisibilityService;
             _logger.LogInformation("AnthropicService instance created. McpToolHelper should be initialized at application startup.");
         }
 
@@ -181,7 +184,13 @@ namespace TelegramSearchBot.Service.AI.LLM {
                     .ToListAsync();
             }
 
-            if (inputMessage != null) {
+            if (_llmVisibilityService != null) {
+                dbMessages = await _llmVisibilityService.FilterVisibleMessagesAsync(chatId, dbMessages);
+            }
+
+            if (inputMessage != null &&
+                ( _llmVisibilityService == null ||
+                  !await _llmVisibilityService.IsUserInvisibleAsync(chatId, inputMessage.FromUserId) )) {
                 dbMessages.Add(inputMessage);
             }
 

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
@@ -398,7 +398,19 @@ namespace TelegramSearchBot.Service.AI.LLM {
             var model = googleAI.CreateGenerativeModel("models/" + modelName);
             var fullResponse = new StringBuilder();
 
+            if (_llmVisibilityService != null &&
+                message != null &&
+                await _llmVisibilityService.IsUserInvisibleAsync(ChatId, message.FromUserId, cancellationToken)) {
+                _chatSessions.Remove(ChatId);
+                yield break;
+            }
+
             var history = await GetChatHistory(ChatId, message, await CheckVisionSupport(modelName, channel.Id));
+            if (_llmVisibilityService != null &&
+                ( await _llmVisibilityService.GetInvisibleUserIdsAsync(ChatId, cancellationToken) ).Count > 0) {
+                _chatSessions.Remove(ChatId);
+            }
+
             if (!_chatSessions.TryGetValue(ChatId, out var chatSession)) {
                 chatSession = model.StartChat(history: history);
                 _chatSessions[ChatId] = chatSession;

--- a/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/GeminiService.cs
@@ -30,6 +30,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly Dictionary<long, ChatSession> _chatSessions = new();
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IBotIdentityProvider _botIdentityProvider;
+        private readonly LlmVisibilityService _llmVisibilityService;
         private string _fallbackBotName = string.Empty;
         public string BotName {
             get => GetBotNameAsync().ConfigureAwait(false).GetAwaiter().GetResult();
@@ -46,18 +47,20 @@ namespace TelegramSearchBot.Service.AI.LLM {
             DataDbContext context,
             ILogger<GeminiService> logger,
             IHttpClientFactory httpClientFactory)
-            : this(context, logger, httpClientFactory, null) {
+            : this(context, logger, httpClientFactory, null, null) {
         }
 
         public GeminiService(
             DataDbContext context,
             ILogger<GeminiService> logger,
             IHttpClientFactory httpClientFactory,
-            IBotIdentityProvider botIdentityProvider) {
+            IBotIdentityProvider botIdentityProvider,
+            LlmVisibilityService llmVisibilityService = null) {
             _logger = logger;
             _dbContext = context;
             _httpClientFactory = httpClientFactory;
             _botIdentityProvider = botIdentityProvider;
+            _llmVisibilityService = llmVisibilityService;
             _logger.LogInformation("GeminiService instance created");
         }
 
@@ -120,7 +123,13 @@ namespace TelegramSearchBot.Service.AI.LLM {
                             .ToListAsync();
             }
 
-            if (inputMessage != null) {
+            if (_llmVisibilityService != null) {
+                messages = await _llmVisibilityService.FilterVisibleMessagesAsync(chatId, messages);
+            }
+
+            if (inputMessage != null &&
+                ( _llmVisibilityService == null ||
+                  !await _llmVisibilityService.IsUserInvisibleAsync(chatId, inputMessage.FromUserId) )) {
                 messages.Add(inputMessage);
             }
 

--- a/TelegramSearchBot.LLM/Service/AI/LLM/LlmVisibilityService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/LlmVisibilityService.cs
@@ -10,7 +10,7 @@ using TelegramSearchBot.Model;
 using TelegramSearchBot.Model.Data;
 
 namespace TelegramSearchBot.Service.AI.LLM {
-    [Injectable(ServiceLifetime.Transient)]
+    [Injectable(ServiceLifetime.Scoped)]
     public class LlmVisibilityService : IService {
         private readonly DataDbContext _dbContext;
 
@@ -73,7 +73,6 @@ namespace TelegramSearchBot.Service.AI.LLM {
                 await _dbContext.UsersWithGroup.AddAsync(userWithGroup, cancellationToken);
             } else {
                 userWithGroup.IsLlmInvisible = isInvisible;
-                _dbContext.UsersWithGroup.Update(userWithGroup);
             }
 
             await _dbContext.SaveChangesAsync(cancellationToken);

--- a/TelegramSearchBot.LLM/Service/AI/LLM/LlmVisibilityService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/LlmVisibilityService.cs
@@ -1,0 +1,83 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using TelegramSearchBot.Attributes;
+using TelegramSearchBot.Interface;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Model.Data;
+
+namespace TelegramSearchBot.Service.AI.LLM {
+    [Injectable(ServiceLifetime.Transient)]
+    public class LlmVisibilityService : IService {
+        private readonly DataDbContext _dbContext;
+
+        public LlmVisibilityService(DataDbContext dbContext) {
+            _dbContext = dbContext;
+        }
+
+        public string ServiceName => "LlmVisibilityService";
+
+        public async Task<bool> IsUserInvisibleAsync(long groupId, long userId, CancellationToken cancellationToken = default) {
+            if (groupId == 0 || userId == 0) return false;
+
+            return await _dbContext.UsersWithGroup.AsNoTracking()
+                .AnyAsync(x => x.GroupId == groupId &&
+                               x.UserId == userId &&
+                               x.IsLlmInvisible,
+                    cancellationToken);
+        }
+
+        public async Task<HashSet<long>> GetInvisibleUserIdsAsync(long groupId, CancellationToken cancellationToken = default) {
+            if (groupId == 0) return new HashSet<long>();
+
+            var userIds = await _dbContext.UsersWithGroup.AsNoTracking()
+                .Where(x => x.GroupId == groupId && x.IsLlmInvisible)
+                .Select(x => x.UserId)
+                .ToListAsync(cancellationToken);
+
+            return userIds.ToHashSet();
+        }
+
+        public async Task<List<Message>> FilterVisibleMessagesAsync(
+            long groupId,
+            IEnumerable<Message> messages,
+            CancellationToken cancellationToken = default) {
+            var messageList = messages?.ToList() ?? new List<Message>();
+            if (messageList.Count == 0) return messageList;
+
+            var invisibleUserIds = await GetInvisibleUserIdsAsync(groupId, cancellationToken);
+            if (invisibleUserIds.Count == 0) return messageList;
+
+            return messageList
+                .Where(message => !invisibleUserIds.Contains(message.FromUserId))
+                .ToList();
+        }
+
+        public async Task<bool> SetUserInvisibleAsync(
+            long groupId,
+            long userId,
+            bool isInvisible,
+            CancellationToken cancellationToken = default) {
+            var userWithGroup = await _dbContext.UsersWithGroup
+                .FirstOrDefaultAsync(x => x.GroupId == groupId && x.UserId == userId, cancellationToken);
+
+            if (userWithGroup == null) {
+                userWithGroup = new UserWithGroup {
+                    GroupId = groupId,
+                    UserId = userId,
+                    IsLlmInvisible = isInvisible
+                };
+                await _dbContext.UsersWithGroup.AddAsync(userWithGroup, cancellationToken);
+            } else {
+                userWithGroup.IsLlmInvisible = isInvisible;
+                _dbContext.UsersWithGroup.Update(userWithGroup);
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken);
+            return userWithGroup.IsLlmInvisible;
+        }
+    }
+}

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIResponsesService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIResponsesService.cs
@@ -64,13 +64,14 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly DataDbContext _dbContext;
         private readonly IHttpClientFactory _httpClientFactory;
         private readonly IMessageExtensionService _messageExtensionService;
+        private readonly LlmVisibilityService _llmVisibilityService;
 
         public OpenAIResponsesService(
             DataDbContext context,
             ILogger<OpenAIResponsesService> logger,
             IMessageExtensionService messageExtensionService,
             IHttpClientFactory httpClientFactory)
-            : this(context, logger, messageExtensionService, httpClientFactory, null) {
+            : this(context, logger, messageExtensionService, httpClientFactory, null, null) {
         }
 
         public OpenAIResponsesService(
@@ -78,12 +79,14 @@ namespace TelegramSearchBot.Service.AI.LLM {
             ILogger<OpenAIResponsesService> logger,
             IMessageExtensionService messageExtensionService,
             IHttpClientFactory httpClientFactory,
-            IBotIdentityProvider botIdentityProvider) {
+            IBotIdentityProvider botIdentityProvider,
+            LlmVisibilityService llmVisibilityService = null) {
             _logger = logger;
             _dbContext = context;
             _messageExtensionService = messageExtensionService;
             _httpClientFactory = httpClientFactory;
             _botIdentityProvider = botIdentityProvider;
+            _llmVisibilityService = llmVisibilityService;
             _logger.LogInformation("OpenAIResponsesService instance created.");
         }
 
@@ -785,7 +788,13 @@ namespace TelegramSearchBot.Service.AI.LLM {
                     .ToListAsync();
             }
 
-            if (inputToken != null) {
+            if (_llmVisibilityService != null) {
+                messages = await _llmVisibilityService.FilterVisibleMessagesAsync(ChatId, messages);
+            }
+
+            if (inputToken != null &&
+                ( _llmVisibilityService == null ||
+                  !await _llmVisibilityService.IsUserInvisibleAsync(ChatId, inputToken.FromUserId) )) {
                 messages.Add(inputToken);
             }
 

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
@@ -112,6 +112,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly IMessageExtensionService _messageExtensionService;
         private readonly IBotIdentityProvider _botIdentityProvider;
         private readonly IGroupLlmSettingsService _groupLlmSettingsService;
+        private readonly LlmVisibilityService _llmVisibilityService;
         private string _fallbackBotName = string.Empty;
 
         public OpenAIService(
@@ -119,7 +120,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             ILogger<OpenAIService> logger,
             IMessageExtensionService messageExtensionService,
             IHttpClientFactory httpClientFactory)
-            : this(context, logger, messageExtensionService, httpClientFactory, null, null) {
+            : this(context, logger, messageExtensionService, httpClientFactory, null, null, null) {
         }
 
         public OpenAIService(
@@ -128,13 +129,15 @@ namespace TelegramSearchBot.Service.AI.LLM {
             IMessageExtensionService messageExtensionService,
             IHttpClientFactory httpClientFactory,
             IBotIdentityProvider botIdentityProvider,
-            IGroupLlmSettingsService groupLlmSettingsService) {
+            IGroupLlmSettingsService groupLlmSettingsService,
+            LlmVisibilityService llmVisibilityService = null) {
             _logger = logger;
             _dbContext = context;
             _messageExtensionService = messageExtensionService;
             _httpClientFactory = httpClientFactory;
             _botIdentityProvider = botIdentityProvider;
             _groupLlmSettingsService = groupLlmSettingsService;
+            _llmVisibilityService = llmVisibilityService;
             _logger.LogInformation("OpenAIService instance created. McpToolHelper should be initialized at application startup.");
         }
 
@@ -836,7 +839,14 @@ namespace TelegramSearchBot.Service.AI.LLM {
                             .OrderBy(m => m.DateTime)
                             .ToListAsync();
             }
-            if (InputToken != null) {
+
+            if (_llmVisibilityService != null) {
+                Messages = await _llmVisibilityService.FilterVisibleMessagesAsync(ChatId, Messages);
+            }
+
+            if (InputToken != null &&
+                ( _llmVisibilityService == null ||
+                  !await _llmVisibilityService.IsUserInvisibleAsync(ChatId, InputToken.FromUserId) )) {
                 Messages.Add(InputToken);
             }
             _logger.LogInformation($"OpenAI GetChatHistory: Found {Messages.Count} messages for ChatId {ChatId}.");

--- a/TelegramSearchBot.Test/Controller/Manage/LlmVisibilityControllerTests.cs
+++ b/TelegramSearchBot.Test/Controller/Manage/LlmVisibilityControllerTests.cs
@@ -1,0 +1,69 @@
+using System.Reflection;
+using TelegramSearchBot.Controller.Manage;
+using Xunit;
+
+namespace TelegramSearchBot.Test.Controller.Manage;
+
+public class LlmVisibilityControllerTests
+{
+    [Theory]
+    [InlineData("/llm_invisible_on")]
+    [InlineData("/llm_invisible_on@TelegramSearchBot")]
+    [InlineData("/LLM_INVISIBLE_ON@TelegramSearchBot")]
+    [InlineData("LLM隐身")]
+    public void IsEnableCommand_MatchesSupportedCommands(string command)
+    {
+        Assert.True(InvokeBool("IsEnableCommand", command));
+    }
+
+    [Theory]
+    [InlineData("/llm_invisible_off")]
+    [InlineData("/llm_invisible_off@TelegramSearchBot")]
+    [InlineData("取消LLM隐身")]
+    [InlineData("LLM显身")]
+    public void IsDisableCommand_MatchesSupportedCommands(string command)
+    {
+        Assert.True(InvokeBool("IsDisableCommand", command));
+    }
+
+    [Theory]
+    [InlineData("/llm_invisible_status")]
+    [InlineData("/llm_invisible_status@TelegramSearchBot")]
+    [InlineData("LLM隐身状态")]
+    public void IsStatusCommand_MatchesSupportedCommands(string command)
+    {
+        Assert.True(InvokeBool("IsStatusCommand", command));
+    }
+
+    [Theory]
+    [InlineData("/llm_invisible_on_bad")]
+    [InlineData("/llm_invisible_off_bad")]
+    [InlineData("/llm_invisible_status_bad")]
+    public void SlashCommandMatching_DoesNotMatchLongerNames(string command)
+    {
+        Assert.False(InvokeBool("IsEnableCommand", command));
+        Assert.False(InvokeBool("IsDisableCommand", command));
+        Assert.False(InvokeBool("IsStatusCommand", command));
+    }
+
+    [Fact]
+    public void NormalizeCommand_PreservesBotSuffixAndDropsArguments()
+    {
+        var method = typeof(LlmVisibilityController).GetMethod(
+            "NormalizeCommand",
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var result = (string)method.Invoke(null, new object[] { "/llm_invisible_on@TelegramSearchBot extra" })!;
+
+        Assert.Equal("/llm_invisible_on@TelegramSearchBot", result);
+    }
+
+    private static bool InvokeBool(string methodName, string command)
+    {
+        var method = typeof(LlmVisibilityController).GetMethod(
+            methodName,
+            BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        return (bool)method.Invoke(null, new object[] { command })!;
+    }
+}

--- a/TelegramSearchBot.Test/Service/AI/LLM/LLMTaskQueueServiceTests.cs
+++ b/TelegramSearchBot.Test/Service/AI/LLM/LLMTaskQueueServiceTests.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Newtonsoft.Json;
 using StackExchange.Redis;
 using TelegramSearchBot.Common;
 using TelegramSearchBot.Model;
@@ -77,6 +78,112 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
                 Assert.Contains("\"InputMessage\":\"custom agent chat input\"", pushedPayload);
                 Assert.Contains("\"ChatId\":-1001", pushedPayload);
                 Assert.Contains("\"UserId\":456", pushedPayload);
+            } finally {
+                Env.EnableLLMAgentProcess = originalFlag;
+            }
+        }
+
+        [Fact]
+        public async Task EnqueueMessageTaskAsync_FiltersInvisibleUsersFromHistoryAndExtensions() {
+            var originalFlag = Env.EnableLLMAgentProcess;
+            Env.EnableLLMAgentProcess = true;
+
+            try {
+                await using var dbContext = CreateDbContext();
+                SeedChannel(dbContext, 323, "gpt-agent-chat");
+                dbContext.GroupSettings.Add(new GroupSettings {
+                    GroupId = -1001,
+                    LLMModelName = "gpt-agent-chat"
+                });
+                dbContext.UsersWithGroup.Add(new UserWithGroup {
+                    GroupId = -1001,
+                    UserId = 222,
+                    IsLlmInvisible = true
+                });
+
+                var visibleMessage = new Message {
+                    GroupId = -1001,
+                    MessageId = 1,
+                    FromUserId = 111,
+                    Content = "visible context",
+                    DateTime = DateTime.UtcNow.AddMinutes(-2)
+                };
+                var hiddenMessage = new Message {
+                    GroupId = -1001,
+                    MessageId = 2,
+                    FromUserId = 222,
+                    Content = "hidden context",
+                    DateTime = DateTime.UtcNow.AddMinutes(-1)
+                };
+                dbContext.Messages.AddRange(visibleMessage, hiddenMessage);
+                await dbContext.SaveChangesAsync();
+
+                dbContext.MessageExtensions.AddRange(
+                    new MessageExtension {
+                        MessageDataId = visibleMessage.Id,
+                        Name = "OCR_Result",
+                        Value = "visible ocr"
+                    },
+                    new MessageExtension {
+                        MessageDataId = hiddenMessage.Id,
+                        Name = "Alt_Result",
+                        Value = "hidden alt"
+                    });
+                await dbContext.SaveChangesAsync();
+
+                var redisMock = new Mock<IConnectionMultiplexer>();
+                var dbMock = new Mock<IDatabase>();
+                redisMock.Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>())).Returns(dbMock.Object);
+
+                dbMock.Setup(d => d.HashGetAllAsync(
+                        It.Is<RedisKey>(key => key == LlmAgentRedisKeys.AgentSession(-1001)),
+                        It.IsAny<CommandFlags>()))
+                    .ReturnsAsync([
+                        new HashEntry("chatId", -1001),
+                        new HashEntry("processId", 999),
+                        new HashEntry("port", 0),
+                        new HashEntry("status", "idle"),
+                        new HashEntry("lastHeartbeatUtc", DateTime.UtcNow.ToString("O")),
+                        new HashEntry("lastActiveAtUtc", DateTime.UtcNow.ToString("O"))
+                    ]);
+
+                string pushedPayload = string.Empty;
+                dbMock.Setup(d => d.ListLeftPushAsync(
+                        It.IsAny<RedisKey>(),
+                        It.IsAny<RedisValue>(),
+                        It.IsAny<When>(),
+                        It.IsAny<CommandFlags>()))
+                    .Callback<RedisKey, RedisValue, When, CommandFlags>((_, value, _, _) => pushedPayload = value.ToString())
+                    .ReturnsAsync(1);
+                dbMock.Setup(d => d.HashSetAsync(It.IsAny<RedisKey>(), It.IsAny<HashEntry[]>(), It.IsAny<CommandFlags>()))
+                    .Returns(Task.CompletedTask);
+
+                var registry = new AgentRegistryService(
+                    redisMock.Object,
+                    Mock.Of<IAgentProcessLauncher>(),
+                    Mock.Of<ILogger<AgentRegistryService>>());
+                var polling = new ChunkPollingService(redisMock.Object);
+                var visibility = new LlmVisibilityService(dbContext);
+                var service = new LLMTaskQueueService(dbContext, redisMock.Object, polling, registry, visibility);
+
+                await service.EnqueueMessageTaskAsync(
+                    -1001,
+                    111,
+                    789,
+                    DateTime.UtcNow,
+                    "current input",
+                    "bot",
+                    1001);
+
+                var task = JsonConvert.DeserializeObject<AgentExecutionTask>(pushedPayload);
+
+                Assert.NotNull(task);
+                Assert.Single(task!.History);
+                Assert.Equal("visible context", task.History[0].Content);
+                Assert.Equal(111, task.History[0].FromUserId);
+                Assert.Contains(task.History[0].Extensions, x => x.Name == "OCR_Result" && x.Value == "visible ocr");
+                Assert.DoesNotContain(task.History, x => x.FromUserId == 222);
+                Assert.DoesNotContain(task.History.SelectMany(x => x.Extensions), x => x.Value == "hidden alt");
             } finally {
                 Env.EnableLLMAgentProcess = originalFlag;
             }

--- a/TelegramSearchBot/Controller/AI/LLM/AgentChatModeController.cs
+++ b/TelegramSearchBot/Controller/AI/LLM/AgentChatModeController.cs
@@ -33,6 +33,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
         private readonly AgentChatExecutionService _executionService;
         private readonly AgentChatBatchQueueService _batchQueueService;
         private readonly IConnectionMultiplexer _redis;
+        private readonly LlmVisibilityService _llmVisibilityService;
         private readonly ILogger<AgentChatModeController> _logger;
 
         public AgentChatModeController(
@@ -44,6 +45,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             AgentChatExecutionService executionService,
             AgentChatBatchQueueService batchQueueService,
             IConnectionMultiplexer redis,
+            LlmVisibilityService llmVisibilityService,
             ILogger<AgentChatModeController> logger) {
             _groupLlmSettingsService = groupLlmSettingsService;
             _botIdentityProvider = botIdentityProvider;
@@ -53,6 +55,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             _executionService = executionService;
             _batchQueueService = batchQueueService;
             _redis = redis;
+            _llmVisibilityService = llmVisibilityService;
             _logger = logger;
         }
 
@@ -81,6 +84,16 @@ namespace TelegramSearchBot.Controller.AI.LLM {
 
             var settings = await _groupLlmSettingsService.GetAgentChatSettingsAsync(telegramMessage.Chat.Id);
             if (!settings.IsEnabled) {
+                return;
+            }
+
+            var senderUserId = telegramMessage.From?.Id ?? 0;
+            if (senderUserId != 0 && await _llmVisibilityService.IsUserInvisibleAsync(telegramMessage.Chat.Id, senderUserId)) {
+                _logger.LogInformation(
+                    "User {UserId} in chat {ChatId} is LLM invisible; skipping agent chat for message {MessageId}.",
+                    senderUserId,
+                    telegramMessage.Chat.Id,
+                    telegramMessage.MessageId);
                 return;
             }
 

--- a/TelegramSearchBot/Controller/AI/LLM/AltPhotoController.cs
+++ b/TelegramSearchBot/Controller/AI/LLM/AltPhotoController.cs
@@ -31,6 +31,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
         private readonly ILogger<AutoOCRController> logger;
         private readonly ISendMessageService SendMessageService;
         private readonly MessageExtensionService MessageExtensionService;
+        private readonly LlmVisibilityService LlmVisibilityService;
         public AltPhotoController(
             ITelegramBotClient botClient,
             IGeneralLLMService generalLLMService,
@@ -38,7 +39,8 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             MessageService messageService,
             ILogger<AutoOCRController> logger,
             ISendMessageService sendMessageService,
-            MessageExtensionService messageExtensionService
+            MessageExtensionService messageExtensionService,
+            LlmVisibilityService llmVisibilityService
             ) {
             this.generalLLMService = generalLLMService;
             this.messageService = messageService;
@@ -47,6 +49,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             this.logger = logger;
             SendMessageService = sendMessageService;
             MessageExtensionService = messageExtensionService;
+            LlmVisibilityService = llmVisibilityService;
         }
         public async Task ExecuteAsync(PipelineContext p) {
             var e = p.Update;
@@ -60,6 +63,12 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             try {
                 var PhotoPath = IProcessPhoto.GetPhotoPath(e);
                 logger.LogInformation($"Get Photo File: {e.Message.Chat.Id}/{e.Message.MessageId}");
+                if (e.Message.From != null &&
+                    await LlmVisibilityService.IsUserInvisibleAsync(e.Message.Chat.Id, e.Message.From.Id)) {
+                    logger.LogInformation("Skip Alt generation for LLM invisible user {UserId} in chat {ChatId}, message {MessageId}",
+                        e.Message.From.Id, e.Message.Chat.Id, e.Message.MessageId);
+                    return;
+                }
                 OcrStr = await generalLLMService.AnalyzeImageAsync(PhotoPath, e.Message.Chat.Id);
                 using (LoggerHolders.PushChatContentLogScope()) {
                     logger.LogInformation(OcrStr);

--- a/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
+++ b/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
@@ -33,6 +33,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
         private readonly MusicGenerationToolSettingsService _musicGenerationToolSettingsService;
         private readonly IModelCapabilityService _modelCapabilityService;
         private readonly IConnectionMultiplexer _connectionMultiplexer;
+        private readonly LlmVisibilityService _llmVisibilityService;
         public List<Type> Dependencies => new List<Type>();
         public ITelegramBotClient botClient { get; set; }
         public MessageService messageService { get; set; }
@@ -56,7 +57,8 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             ImageGenerationToolSettingsService imageGenerationToolSettingsService,
             MusicGenerationToolSettingsService musicGenerationToolSettingsService,
             IModelCapabilityService modelCapabilityService,
-            IConnectionMultiplexer connectionMultiplexer
+            IConnectionMultiplexer connectionMultiplexer,
+            LlmVisibilityService llmVisibilityService
             ) {
             this.logger = logger;
             this.botClient = botClient;
@@ -73,6 +75,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             _musicGenerationToolSettingsService = musicGenerationToolSettingsService;
             _modelCapabilityService = modelCapabilityService;
             _connectionMultiplexer = connectionMultiplexer;
+            _llmVisibilityService = llmVisibilityService;
 
         }
         public async Task ExecuteAsync(PipelineContext p) {
@@ -242,6 +245,13 @@ namespace TelegramSearchBot.Controller.AI.LLM {
             bool isReplyToBot = telegramMessage.ReplyToMessage != null && telegramMessage.ReplyToMessage.From != null && telegramMessage.ReplyToMessage.From.Id == botIdentity.UserId;
 
             if (isMentionToBot || isReplyToBot) {
+                if (fromUserId != 0 && await _llmVisibilityService.IsUserInvisibleAsync(telegramMessage.Chat.Id, fromUserId)) {
+                    logger.LogInformation("User {UserId} in chat {ChatId} is LLM invisible; skipping LLM execution for message {MessageId}.",
+                        fromUserId, telegramMessage.Chat.Id, telegramMessage.MessageId);
+                    await SendMessageService.SendMessage("你已开启 LLM 隐身，这条消息不会发送给 LLM。发送 `取消LLM隐身` 可恢复。", telegramMessage.Chat.Id, telegramMessage.MessageId);
+                    return;
+                }
+
                 var modelName = await _groupLlmSettingsService.GetModelAsync(telegramMessage.Chat.Id);
                 if (string.IsNullOrWhiteSpace(modelName)) {
                     logger.LogWarning("请指定模型名称");

--- a/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
+++ b/TelegramSearchBot/Controller/AI/LLM/GeneralLLMController.cs
@@ -248,7 +248,7 @@ namespace TelegramSearchBot.Controller.AI.LLM {
                 if (fromUserId != 0 && await _llmVisibilityService.IsUserInvisibleAsync(telegramMessage.Chat.Id, fromUserId)) {
                     logger.LogInformation("User {UserId} in chat {ChatId} is LLM invisible; skipping LLM execution for message {MessageId}.",
                         fromUserId, telegramMessage.Chat.Id, telegramMessage.MessageId);
-                    await SendMessageService.SendMessage("你已开启 LLM 隐身，这条消息不会发送给 LLM。发送 `取消LLM隐身` 可恢复。", telegramMessage.Chat.Id, telegramMessage.MessageId);
+                    await SendLlmInvisibleNoticeAsync(telegramMessage.Chat.Id, fromUserId, telegramMessage.MessageId);
                     return;
                 }
 
@@ -537,6 +537,14 @@ namespace TelegramSearchBot.Controller.AI.LLM {
 
         private static string GetMusicGenerationModelSelectionKey(long chatId, long userId) {
             return LlmAgentRedisKeys.MusicGenerationModelSelection(chatId, userId);
+        }
+
+        private async Task SendLlmInvisibleNoticeAsync(long chatId, long userId, int replyToMessageId) {
+            var db = _connectionMultiplexer.GetDatabase();
+            var key = $"llm_invisible_notice:{chatId}:{userId}";
+            if (await db.StringSetAsync(key, "1", TimeSpan.FromMinutes(10), When.NotExists)) {
+                await SendMessageService.SendMessage("你已开启 LLM 隐身，这条消息不会发送给 LLM。发送 `取消LLM隐身` 可恢复。", chatId, replyToMessageId);
+            }
         }
 
         private sealed record ImageGenerationModelSelectionOption(string ModelName, string ChannelSummary);

--- a/TelegramSearchBot/Controller/Manage/LlmVisibilityController.cs
+++ b/TelegramSearchBot/Controller/Manage/LlmVisibilityController.cs
@@ -63,28 +63,31 @@ namespace TelegramSearchBot.Controller.Manage {
                 command = command.Substring(0, tokenEnd);
             }
 
-            var botSuffixStart = command.IndexOf('@');
-            if (botSuffixStart >= 0) {
-                command = command.Substring(0, botSuffixStart);
-            }
-
             return command.Trim();
         }
 
         private static bool IsEnableCommand(string command) {
             return command.Equals("LLM隐身", StringComparison.OrdinalIgnoreCase) ||
-                   command.Equals("/llm_invisible_on", StringComparison.OrdinalIgnoreCase);
+                   IsSlashCommand(command, "/llm_invisible_on");
         }
 
         private static bool IsDisableCommand(string command) {
             return command.Equals("取消LLM隐身", StringComparison.OrdinalIgnoreCase) ||
                    command.Equals("LLM显身", StringComparison.OrdinalIgnoreCase) ||
-                   command.Equals("/llm_invisible_off", StringComparison.OrdinalIgnoreCase);
+                   IsSlashCommand(command, "/llm_invisible_off");
         }
 
         private static bool IsStatusCommand(string command) {
             return command.Equals("LLM隐身状态", StringComparison.OrdinalIgnoreCase) ||
-                   command.Equals("/llm_invisible_status", StringComparison.OrdinalIgnoreCase);
+                   IsSlashCommand(command, "/llm_invisible_status");
+        }
+
+        private static bool IsSlashCommand(string command, string expectedCommand) {
+            if (!command.StartsWith(expectedCommand, StringComparison.OrdinalIgnoreCase)) {
+                return false;
+            }
+
+            return command.Length == expectedCommand.Length || command[expectedCommand.Length] == '@';
         }
     }
 }

--- a/TelegramSearchBot/Controller/Manage/LlmVisibilityController.cs
+++ b/TelegramSearchBot/Controller/Manage/LlmVisibilityController.cs
@@ -28,7 +28,7 @@ namespace TelegramSearchBot.Controller.Manage {
                 return;
             }
 
-            var command = ( message.Text ?? message.Caption ?? string.Empty ).Trim();
+            var command = NormalizeCommand(message.Text ?? message.Caption ?? string.Empty);
             if (string.IsNullOrWhiteSpace(command)) {
                 return;
             }
@@ -50,6 +50,25 @@ namespace TelegramSearchBot.Controller.Manage {
                 var status = enabled ? "已开启" : "未开启";
                 await _sendMessageService.SendMessage($"LLM 隐身状态：{status}", message.Chat.Id, message.MessageId);
             }
+        }
+
+        private static string NormalizeCommand(string rawCommand) {
+            var command = rawCommand.Trim();
+            if (string.IsNullOrWhiteSpace(command)) {
+                return string.Empty;
+            }
+
+            var tokenEnd = command.IndexOfAny(new[] { ' ', '\r', '\n', '\t' });
+            if (tokenEnd >= 0) {
+                command = command.Substring(0, tokenEnd);
+            }
+
+            var botSuffixStart = command.IndexOf('@');
+            if (botSuffixStart >= 0) {
+                command = command.Substring(0, botSuffixStart);
+            }
+
+            return command.Trim();
         }
 
         private static bool IsEnableCommand(string command) {

--- a/TelegramSearchBot/Controller/Manage/LlmVisibilityController.cs
+++ b/TelegramSearchBot/Controller/Manage/LlmVisibilityController.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Telegram.Bot.Types;
+using TelegramSearchBot.Interface;
+using TelegramSearchBot.Interface.Controller;
+using TelegramSearchBot.Model;
+using TelegramSearchBot.Service.AI.LLM;
+using TelegramSearchBot.Controller.Storage;
+
+namespace TelegramSearchBot.Controller.Manage {
+    public class LlmVisibilityController : IOnUpdate {
+        private readonly LlmVisibilityService _llmVisibilityService;
+        private readonly ISendMessageService _sendMessageService;
+
+        public LlmVisibilityController(
+            LlmVisibilityService llmVisibilityService,
+            ISendMessageService sendMessageService) {
+            _llmVisibilityService = llmVisibilityService;
+            _sendMessageService = sendMessageService;
+        }
+
+        public List<Type> Dependencies => new List<Type> { typeof(MessageController) };
+
+        public async Task ExecuteAsync(PipelineContext p) {
+            var message = p.Update.Message;
+            if (message == null || message.Chat.Id >= 0 || message.From == null) {
+                return;
+            }
+
+            var command = ( message.Text ?? message.Caption ?? string.Empty ).Trim();
+            if (string.IsNullOrWhiteSpace(command)) {
+                return;
+            }
+
+            if (IsEnableCommand(command)) {
+                await _llmVisibilityService.SetUserInvisibleAsync(message.Chat.Id, message.From.Id, true);
+                await _sendMessageService.SendMessage("已开启 LLM 隐身。之后你的群消息、图片 Alt 和消息扩展信息都不会发送给 LLM。", message.Chat.Id, message.MessageId);
+                return;
+            }
+
+            if (IsDisableCommand(command)) {
+                await _llmVisibilityService.SetUserInvisibleAsync(message.Chat.Id, message.From.Id, false);
+                await _sendMessageService.SendMessage("已关闭 LLM 隐身。之后你的群消息可以进入 LLM 上下文。", message.Chat.Id, message.MessageId);
+                return;
+            }
+
+            if (IsStatusCommand(command)) {
+                var enabled = await _llmVisibilityService.IsUserInvisibleAsync(message.Chat.Id, message.From.Id);
+                var status = enabled ? "已开启" : "未开启";
+                await _sendMessageService.SendMessage($"LLM 隐身状态：{status}", message.Chat.Id, message.MessageId);
+            }
+        }
+
+        private static bool IsEnableCommand(string command) {
+            return command.Equals("LLM隐身", StringComparison.OrdinalIgnoreCase) ||
+                   command.Equals("/llm_invisible_on", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsDisableCommand(string command) {
+            return command.Equals("取消LLM隐身", StringComparison.OrdinalIgnoreCase) ||
+                   command.Equals("LLM显身", StringComparison.OrdinalIgnoreCase) ||
+                   command.Equals("/llm_invisible_off", StringComparison.OrdinalIgnoreCase);
+        }
+
+        private static bool IsStatusCommand(string command) {
+            return command.Equals("LLM隐身状态", StringComparison.OrdinalIgnoreCase) ||
+                   command.Equals("/llm_invisible_status", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/TelegramSearchBot/Service/AI/LLM/AgentChatBatchDispatchService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/AgentChatBatchDispatchService.cs
@@ -118,11 +118,23 @@ return 0";
                     return;
                 }
 
-                var last = bufferedMessages[^1];
+                var llmVisibilityService = scope.ServiceProvider.GetRequiredService<LlmVisibilityService>();
+                var visibleBufferedMessages = await FilterVisibleBufferedMessagesAsync(
+                    llmVisibilityService,
+                    chatId,
+                    bufferedMessages,
+                    cancellationToken);
+                if (visibleBufferedMessages.Count == 0) {
+                    _logger.LogInformation("Dropping agent chat batch after LLM invisibility filtering. ChatId={ChatId}", chatId);
+                    await db.KeyDeleteAsync(LlmAgentRedisKeys.AgentChatBatchMeta(chatId));
+                    return;
+                }
+
+                var last = visibleBufferedMessages[^1];
                 var executionService = scope.ServiceProvider.GetRequiredService<AgentChatExecutionService>();
                 await executionService.ExecuteAsync(new AgentChatExecutionRequest {
                     ReplyTarget = last.Message,
-                    InputMessage = BuildBatchInput(bufferedMessages),
+                    InputMessage = BuildBatchInput(visibleBufferedMessages),
                     BotName = last.BotName,
                     BotUserId = last.BotUserId,
                     ModelName = settings.ModelName ?? string.Empty,
@@ -188,6 +200,21 @@ return 0";
             return result
                 .OrderBy(x => x.Message.DateTime)
                 .ThenBy(x => x.Message.MessageId)
+                .ToList();
+        }
+
+        private static async Task<List<AgentChatBufferedMessage>> FilterVisibleBufferedMessagesAsync(
+            LlmVisibilityService llmVisibilityService,
+            long chatId,
+            List<AgentChatBufferedMessage> bufferedMessages,
+            CancellationToken cancellationToken) {
+            var invisibleUserIds = await llmVisibilityService.GetInvisibleUserIdsAsync(chatId, cancellationToken);
+            if (invisibleUserIds.Count == 0) {
+                return bufferedMessages;
+            }
+
+            return bufferedMessages
+                .Where(x => !invisibleUserIds.Contains(x.Message.UserId))
                 .ToList();
         }
 

--- a/TelegramSearchBot/Service/AI/LLM/LLMTaskQueueService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/LLMTaskQueueService.cs
@@ -22,16 +22,19 @@ namespace TelegramSearchBot.Service.AI.LLM {
         private readonly IConnectionMultiplexer _redis;
         private readonly ChunkPollingService _chunkPollingService;
         private readonly AgentRegistryService _agentRegistryService;
+        private readonly LlmVisibilityService _llmVisibilityService;
 
         public LLMTaskQueueService(
             DataDbContext dbContext,
             IConnectionMultiplexer redis,
             ChunkPollingService chunkPollingService,
-            AgentRegistryService agentRegistryService) {
+            AgentRegistryService agentRegistryService,
+            LlmVisibilityService llmVisibilityService = null) {
             _dbContext = dbContext;
             _redis = redis;
             _chunkPollingService = chunkPollingService;
             _agentRegistryService = agentRegistryService;
+            _llmVisibilityService = llmVisibilityService;
         }
 
         public string ServiceName => nameof(LLMTaskQueueService);
@@ -262,6 +265,10 @@ namespace TelegramSearchBot.Service.AI.LLM {
                     .Take(10)
                     .OrderBy(x => x.DateTime)
                     .ToListAsync(cancellationToken);
+            }
+
+            if (_llmVisibilityService != null) {
+                history = await _llmVisibilityService.FilterVisibleMessagesAsync(chatId, history, cancellationToken);
             }
 
             var userIds = history.Select(x => x.FromUserId).Distinct().ToList();

--- a/TelegramSearchBot/Service/BotAPI/TelegramCommandRegistryService.cs
+++ b/TelegramSearchBot/Service/BotAPI/TelegramCommandRegistryService.cs
@@ -26,6 +26,9 @@ namespace TelegramSearchBot.Service.BotAPI {
                     new BotCommand { Command = "resolveurls", Description = "解析文本中的链接并存储原始链接与解析后链接的映射。" },
                     new BotCommand { Command = "checkupdate", Description = "检查系统更新状态。" },
                     new BotCommand { Command = "update", Description = "执行系统更新（如果存在新版本）。" },
+                    new BotCommand { Command = "llm_invisible_on", Description = "开启当前群的 LLM 隐身。" },
+                    new BotCommand { Command = "llm_invisible_off", Description = "关闭当前群的 LLM 隐身。" },
+                    new BotCommand { Command = "llm_invisible_status", Description = "查看当前群的 LLM 隐身状态。" },
                 };
 
                 _logger.LogInformation($"Registering {commands.Count} commands...");

--- a/TelegramSearchBot/Service/Manage/RefreshService.cs
+++ b/TelegramSearchBot/Service/Manage/RefreshService.cs
@@ -40,6 +40,7 @@ namespace TelegramSearchBot.Service.Manage {
         private readonly IGeneralLLMService _generalLLMService;
         private readonly FaissVectorService _faissVectorService;
         private readonly ConversationSegmentationService _conversationSegmentationService;
+        private readonly LlmVisibilityService _llmVisibilityService;
 
         public RefreshService(ILogger<RefreshService> logger,
                             LuceneManager lucene,
@@ -53,7 +54,8 @@ namespace TelegramSearchBot.Service.Manage {
                             IGeneralLLMService generalLLMService,
                             IMediator mediator,
                             FaissVectorService faissVectorService,
-                            ConversationSegmentationService conversationSegmentationService) : base(logger, lucene, Send, context, mediator) {
+                            ConversationSegmentationService conversationSegmentationService,
+                            LlmVisibilityService llmVisibilityService) : base(logger, lucene, Send, context, mediator) {
             _logger = logger;
             _chatImport = chatImport;
             _autoASRService = autoASRService;
@@ -63,6 +65,7 @@ namespace TelegramSearchBot.Service.Manage {
             _generalLLMService = generalLLMService;
             _faissVectorService = faissVectorService;
             _conversationSegmentationService = conversationSegmentationService;
+            _llmVisibilityService = llmVisibilityService;
         }
 
         private async Task RebuildIndex() {
@@ -322,6 +325,12 @@ namespace TelegramSearchBot.Service.Manage {
                         var messageDataId = await _messageExtensionService.GetMessageIdByMessageIdAndGroupId(messageId, chatId);
                         if (messageDataId.HasValue) {
                             var extensions = await _messageExtensionService.GetByMessageDataIdAsync(messageDataId.Value);
+                            var message = await DataContext.Messages.AsNoTracking()
+                                .FirstOrDefaultAsync(m => m.Id == messageDataId.Value);
+                            if (message != null &&
+                                await _llmVisibilityService.IsUserInvisibleAsync(chatId, message.FromUserId)) {
+                                continue;
+                            }
 
                             // 处理Alt信息
                             if (!extensions.Any(x => x.Name == "Alt_Result")) {

--- a/TelegramSearchBot/Service/Manage/RefreshService.cs
+++ b/TelegramSearchBot/Service/Manage/RefreshService.cs
@@ -315,6 +315,14 @@ namespace TelegramSearchBot.Service.Manage {
 
             await Send.Log($"开始处理图片Alt信息，共{totalFiles}个文件");
 
+            async Task ReportProgressAsync() {
+                processedFiles++;
+                if (filesPerPercent > 0 && processedFiles >= nextPercent * filesPerPercent) {
+                    await Send.Log($"图片Alt处理进度: {nextPercent}% ({processedFiles}/{totalFiles})");
+                    nextPercent++;
+                }
+            }
+
             foreach (var chatDir in chatDirs) {
                 var chatId = long.Parse(Path.GetFileName(chatDir));
                 var imageFiles = Directory.GetFiles(chatDir);
@@ -329,6 +337,7 @@ namespace TelegramSearchBot.Service.Manage {
                                 .FirstOrDefaultAsync(m => m.Id == messageDataId.Value);
                             if (message != null &&
                                 await _llmVisibilityService.IsUserInvisibleAsync(chatId, message.FromUserId)) {
+                                await ReportProgressAsync();
                                 continue;
                             }
 
@@ -344,11 +353,7 @@ namespace TelegramSearchBot.Service.Manage {
                         }
                     }
 
-                    processedFiles++;
-                    if (filesPerPercent > 0 && processedFiles >= nextPercent * filesPerPercent) {
-                        await Send.Log($"图片Alt处理进度: {nextPercent}% ({processedFiles}/{totalFiles})");
-                        nextPercent++;
-                    }
+                    await ReportProgressAsync();
                 }
             }
             await Send.Log($"图片Alt处理完成: 100% ({totalFiles}/{totalFiles})");

--- a/TelegramSearchBot/Service/Tools/SearchToolService.cs
+++ b/TelegramSearchBot/Service/Tools/SearchToolService.cs
@@ -30,11 +30,11 @@ namespace TelegramSearchBot.Service.Tools {
             LuceneManager luceneManager,
             DataDbContext dbContext,
             MessageExtensionService messageExtensionService,
-            LlmVisibilityService llmVisibilityService = null) {
+            LlmVisibilityService llmVisibilityService) {
             _luceneManager = luceneManager;
             _dbContext = dbContext;
             _messageExtensionService = messageExtensionService;
-            _llmVisibilityService = llmVisibilityService;
+            _llmVisibilityService = llmVisibilityService ?? throw new ArgumentNullException(nameof(llmVisibilityService));
         }
 
         [BuiltInTool("Searches indexed messages within the current chat using keywords. Supports pagination.")]
@@ -323,9 +323,7 @@ namespace TelegramSearchBot.Service.Tools {
         }
 
         private async Task<HashSet<long>> GetInvisibleUserIdsAsync(long chatId) {
-            return _llmVisibilityService == null
-                ? new HashSet<long>()
-                : await _llmVisibilityService.GetInvisibleUserIdsAsync(chatId);
+            return await _llmVisibilityService.GetInvisibleUserIdsAsync(chatId);
         }
 
         private (int totalHits, List<TelegramSearchBot.Search.Model.MessageDTO> messageDtos) SearchVisibleLuceneMessages(
@@ -347,7 +345,11 @@ namespace TelegramSearchBot.Service.Tools {
                 if (visibleDtos.Count >= requiredVisibleCount ||
                     searchResult.Item2.Count >= searchResult.Item1 ||
                     fetchSize >= maxFetchSize) {
-                    return (visibleDtos.Count, visibleDtos.Skip(skip).Take(take).ToList());
+                    var invisibleHitsInFetchedSet = searchResult.Item2.Count(m => invisibleUserIds.Contains(m.FromUserId));
+                    var totalVisibleFound = searchResult.Item2.Count >= searchResult.Item1
+                        ? visibleDtos.Count
+                        : Math.Max(0, searchResult.Item1 - invisibleHitsInFetchedSet);
+                    return (totalVisibleFound, visibleDtos.Skip(skip).Take(take).ToList());
                 }
 
                 fetchSize = Math.Min(maxFetchSize, fetchSize * 2);

--- a/TelegramSearchBot/Service/Tools/SearchToolService.cs
+++ b/TelegramSearchBot/Service/Tools/SearchToolService.cs
@@ -24,11 +24,17 @@ namespace TelegramSearchBot.Service.Tools {
         private readonly LuceneManager _luceneManager;
         private readonly DataDbContext _dbContext;
         private readonly MessageExtensionService _messageExtensionService;
+        private readonly LlmVisibilityService _llmVisibilityService;
 
-        public SearchToolService(LuceneManager luceneManager, DataDbContext dbContext, MessageExtensionService messageExtensionService) {
+        public SearchToolService(
+            LuceneManager luceneManager,
+            DataDbContext dbContext,
+            MessageExtensionService messageExtensionService,
+            LlmVisibilityService llmVisibilityService = null) {
             _luceneManager = luceneManager;
             _dbContext = dbContext;
             _messageExtensionService = messageExtensionService;
+            _llmVisibilityService = llmVisibilityService;
         }
 
         [BuiltInTool("Searches indexed messages within the current chat using keywords. Supports pagination.")]
@@ -46,9 +52,14 @@ namespace TelegramSearchBot.Service.Tools {
             int skip = ( page - 1 ) * pageSize;
             int take = pageSize;
 
+            var invisibleUserIds = await GetInvisibleUserIdsAsync(chatId);
             (int totalHits, List<TelegramSearchBot.Search.Model.MessageDTO> messageDtos) searchResult;
             try {
-                searchResult = _luceneManager.Search(query, chatId, skip, take);
+                if (invisibleUserIds.Count == 0) {
+                    searchResult = _luceneManager.Search(query, chatId, skip, take);
+                } else {
+                    searchResult = SearchVisibleLuceneMessages(query, chatId, skip, take, invisibleUserIds);
+                }
             } catch (System.IO.DirectoryNotFoundException) {
                 return new SearchToolResult { Query = query, TotalFound = 0, CurrentPage = page, PageSize = pageSize, Results = new List<SearchResultItem>(), Note = $"No search index found for this chat. Messages may not have been indexed yet." };
             } catch (Exception ex) {
@@ -62,14 +73,18 @@ namespace TelegramSearchBot.Service.Tools {
                 // Get context messages
                 var messagesBefore = await _dbContext.Messages
                     .Include(m => m.MessageExtensions)
-                    .Where(m => m.GroupId == chatId && m.DateTime < msg.DateTime)
+                    .Where(m => m.GroupId == chatId &&
+                                m.DateTime < msg.DateTime &&
+                                !invisibleUserIds.Contains(m.FromUserId))
                     .OrderByDescending(m => m.DateTime)
                     .Take(5)
                     .ToListAsync();
 
                 var messagesAfter = await _dbContext.Messages
                     .Include(m => m.MessageExtensions)
-                    .Where(m => m.GroupId == chatId && m.DateTime > msg.DateTime)
+                    .Where(m => m.GroupId == chatId &&
+                                m.DateTime > msg.DateTime &&
+                                !invisibleUserIds.Contains(m.FromUserId))
                     .OrderBy(m => m.DateTime)
                     .Take(5)
                     .ToListAsync();
@@ -158,8 +173,13 @@ namespace TelegramSearchBot.Service.Tools {
             }
 
             try {
+                var invisibleUserIds = await GetInvisibleUserIdsAsync(chatId);
                 var query = _dbContext.Messages.AsNoTracking()
                                      .Where(m => m.GroupId == chatId);
+
+                if (invisibleUserIds.Count > 0) {
+                    query = query.Where(m => !invisibleUserIds.Contains(m.FromUserId));
+                }
 
                 if (!string.IsNullOrWhiteSpace(queryText)) {
                     query = query.Where(m => m.Content != null && m.Content.Contains(queryText));
@@ -217,14 +237,18 @@ namespace TelegramSearchBot.Service.Tools {
                     // Get context messages
                     var messagesBefore = await _dbContext.Messages
                         .Include(m => m.MessageExtensions)
-                        .Where(m => m.GroupId == chatId && m.DateTime < msg.DateTime)
+                        .Where(m => m.GroupId == chatId &&
+                                    m.DateTime < msg.DateTime &&
+                                    !invisibleUserIds.Contains(m.FromUserId))
                         .OrderByDescending(m => m.DateTime)
                         .Take(5)
                         .ToListAsync();
 
                     var messagesAfter = await _dbContext.Messages
                         .Include(m => m.MessageExtensions)
-                        .Where(m => m.GroupId == chatId && m.DateTime > msg.DateTime)
+                        .Where(m => m.GroupId == chatId &&
+                                    m.DateTime > msg.DateTime &&
+                                    !invisibleUserIds.Contains(m.FromUserId))
                         .OrderBy(m => m.DateTime)
                         .Take(5)
                         .ToListAsync();
@@ -295,6 +319,38 @@ namespace TelegramSearchBot.Service.Tools {
                     Results = new List<HistoryMessageItem>(),
                     Note = $"An error occurred while querying history: {ex.Message}"
                 };
+            }
+        }
+
+        private async Task<HashSet<long>> GetInvisibleUserIdsAsync(long chatId) {
+            return _llmVisibilityService == null
+                ? new HashSet<long>()
+                : await _llmVisibilityService.GetInvisibleUserIdsAsync(chatId);
+        }
+
+        private (int totalHits, List<TelegramSearchBot.Search.Model.MessageDTO> messageDtos) SearchVisibleLuceneMessages(
+            string query,
+            long chatId,
+            int skip,
+            int take,
+            HashSet<long> invisibleUserIds) {
+            var requiredVisibleCount = skip + take;
+            var fetchSize = Math.Max(requiredVisibleCount, 100);
+            const int maxFetchSize = 1000;
+
+            while (true) {
+                var searchResult = _luceneManager.Search(query, chatId, 0, fetchSize);
+                var visibleDtos = searchResult.Item2
+                    .Where(m => !invisibleUserIds.Contains(m.FromUserId))
+                    .ToList();
+
+                if (visibleDtos.Count >= requiredVisibleCount ||
+                    searchResult.Item2.Count >= searchResult.Item1 ||
+                    fetchSize >= maxFetchSize) {
+                    return (visibleDtos.Count, visibleDtos.Skip(skip).Take(take).ToList());
+                }
+
+                fetchSize = Math.Min(maxFetchSize, fetchSize * 2);
             }
         }
     }


### PR DESCRIPTION
## Summary
- add per-group `IsLlmInvisible` flag and self-service commands for users to enable/disable/check LLM invisibility
- filter invisible users out of provider chat history, agent task history, LLM search/history tool results, and agent chat batch inputs
- skip Alt generation for invisible users in both realtime photo handling and RefreshService batch Alt refresh

## Tests
- dotnet build TelegramSearchBot.sln --configuration Release --no-restore
- dotnet test TelegramSearchBot.sln --no-restore --no-build --configuration Release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now mark themselves as invisible to LLM features within specific groups.
  * Added ability to toggle invisibility status and check current visibility state.
  * AI processing now respects invisibility settings—invisible users' messages are excluded from LLM context and analysis across all AI services.

* **Tests**
  * Added test coverage for invisibility filtering and visibility state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->