### PR TITLE
Test and harden long-image OCR slicing

### DIFF
--- a/TelegramSearchBot.Test/Service/AI/OCR/LongImageOcrSlicerTests.cs
+++ b/TelegramSearchBot.Test/Service/AI/OCR/LongImageOcrSlicerTests.cs
@@ -54,18 +54,39 @@ namespace TelegramSearchBot.Test.Service.AI.OCR {
         }
 
         [Fact]
-        public void MergeResults_RemovesRepeatedBoundaryLines() {
+        public void PlanSlices_SingleBlankRowStillUsesOverlap() {
+            using var image = CreateDenseImage(800, 7000);
+            FillRows(image, LongImageOcrSlicer.TargetSliceHeight, LongImageOcrSlicer.TargetSliceHeight + 1, SKColors.White);
+
+            var slices = LongImageOcrSlicer.PlanSlices(image);
+
+            Assert.True(slices[1].HasOverlap);
+            AssertCompleteCoverage(slices, image.Height);
+        }
+
+        [Fact]
+        public void MergeResults_RemovesRepeatedBoundaryLinesFromOverlappingSlices() {
             var result = LongImageOcrSlicer.MergeResults([
-                "第一段 重叠块一 重叠块二",
-                "重叠块一 重叠块二 第二段",
-                "第三段"
+                (new OcrImageSlice(0, 3072, false), "第一段 重叠块一 重叠块二"),
+                (new OcrImageSlice(2976, 3072, true), "重叠块一 重叠块二 第二段"),
+                (new OcrImageSlice(6048, 952, false), "第三段")
             ]);
 
             Assert.Equal("第一段 重叠块一 重叠块二 第二段 第三段", result);
         }
 
         [Fact]
-        public async Task ExecuteAsync_LongImage_RunsSlicesInOrderAndMergesResults() {
+        public void MergeResults_PreservesRepeatedBoundaryTokensWithoutOverlap() {
+            var result = LongImageOcrSlicer.MergeResults([
+                (new OcrImageSlice(0, 3072, false), "第一段 2026"),
+                (new OcrImageSlice(3072, 3928, false), "2026 第二段")
+            ]);
+
+            Assert.Equal("第一段 2026 2026 第二段", result);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_LongImage_PreservesRepeatedTokensAcrossSafeCut() {
             var calls = new List<(int Width, int Height)>();
             var responses = new Queue<string>(["第一段 重叠块", "重叠块 第二段"]);
             var service = new PaddleOCRService(
@@ -82,6 +103,19 @@ namespace TelegramSearchBot.Test.Service.AI.OCR {
             Assert.Equal(2, calls.Count);
             Assert.All(calls, call => Assert.Equal(1000, call.Width));
             Assert.All(calls, call => Assert.InRange(call.Height, 1, LongImageOcrSlicer.LongImageHeightThreshold));
+            Assert.Equal("第一段 重叠块 重叠块 第二段", result);
+        }
+
+        [Fact]
+        public async Task ExecuteAsync_OverlappingSlicesRemoveRepeatedBoundaryTokens() {
+            var responses = new Queue<string>(["第一段 重叠块", "重叠块 第二段"]);
+            var service = new PaddleOCRService(
+                Mock.Of<IConnectionMultiplexer>(),
+                payload => Task.FromResult(responses.Dequeue()));
+            using var stream = Encode(CreateDenseImage(1000, 5000));
+
+            var result = await service.ExecuteAsync(stream);
+
             Assert.Equal("第一段 重叠块 第二段", result);
         }
 
@@ -121,11 +155,11 @@ namespace TelegramSearchBot.Test.Service.AI.OCR {
         }
 
         private static SKBitmap CreateDenseImage(int width, int height) {
-            var image = new SKBitmap(width, height);
-            for (var y = 0; y < height; y++) {
-                for (var x = 0; x < width; x++) {
-                    image.SetPixel(x, y, x % 16 < 8 ? SKColors.Black : SKColors.White);
-                }
+            var image = CreateWhiteImage(width, height);
+            using var canvas = new SKCanvas(image);
+            using var paint = new SKPaint { Color = SKColors.Black };
+            for (var x = 0; x < width; x += 16) {
+                canvas.DrawRect(x, 0, 8, height, paint);
             }
             return image;
         }
@@ -137,11 +171,9 @@ namespace TelegramSearchBot.Test.Service.AI.OCR {
         }
 
         private static void FillRows(SKBitmap image, int start, int end, SKColor color) {
-            for (var y = start; y < end; y++) {
-                for (var x = 0; x < image.Width; x++) {
-                    image.SetPixel(x, y, color);
-                }
-            }
+            using var canvas = new SKCanvas(image);
+            using var paint = new SKPaint { Color = color };
+            canvas.DrawRect(0, start, image.Width, end - start, paint);
         }
 
         private static MemoryStream Encode(SKBitmap image) {

--- a/TelegramSearchBot/Service/AI/OCR/LongImageOcrSlicer.cs
+++ b/TelegramSearchBot/Service/AI/OCR/LongImageOcrSlicer.cs
@@ -16,6 +16,7 @@ namespace TelegramSearchBot.Service.AI.OCR {
         private const int AnalysisWidth = 256;
         private const int MinimumSliceHeight = 1024;
         private const int BrightnessDifferenceThreshold = 24;
+        private const int CutDensityRadius = 3;
         private const double SafeRowDensityThreshold = 0.025;
 
         internal static IReadOnlyList<OcrImageSlice> PlanSlices(SKBitmap image) {
@@ -33,7 +34,7 @@ namespace TelegramSearchBot.Service.AI.OCR {
                 var searchStart = Math.Max(top + MinimumSliceHeight, targetBottom - CutSearchRadius);
                 var searchEnd = Math.Min(image.Height - 1, targetBottom + CutSearchRadius);
                 var cut = FindBestCut(rowDensities, searchStart, searchEnd);
-                var safeCut = rowDensities[cut] <= SafeRowDensityThreshold;
+                var safeCut = AverageDensity(rowDensities, cut, CutDensityRadius) <= SafeRowDensityThreshold;
                 var hasOverlap = slices.Count > 0 && slices[^1].Top + slices[^1].Height > top;
 
                 slices.Add(new OcrImageSlice(top, cut - top, hasOverlap));
@@ -44,13 +45,22 @@ namespace TelegramSearchBot.Service.AI.OCR {
             return slices;
         }
 
-        internal static string MergeResults(IEnumerable<string> results) {
+        internal static string MergeResults(IEnumerable<(OcrImageSlice Slice, string Text)> results) {
             var mergedTokens = new List<string>();
+            var previousSliceHadText = false;
 
-            foreach (var result in results.Where(result => !string.IsNullOrWhiteSpace(result))) {
-                var nextTokens = SplitTokens(result);
-                var duplicateTokenCount = FindDuplicateBoundary(mergedTokens, nextTokens);
+            foreach (var (slice, text) in results) {
+                if (string.IsNullOrWhiteSpace(text)) {
+                    previousSliceHadText = false;
+                    continue;
+                }
+
+                var nextTokens = SplitTokens(text);
+                var duplicateTokenCount = slice.HasOverlap && previousSliceHadText
+                    ? FindDuplicateBoundary(mergedTokens, nextTokens)
+                    : 0;
                 mergedTokens.AddRange(nextTokens.Skip(duplicateTokenCount));
+                previousSliceHadText = true;
             }
 
             return string.Join(' ', mergedTokens);
@@ -97,7 +107,7 @@ namespace TelegramSearchBot.Service.AI.OCR {
             var bestScore = double.MaxValue;
 
             for (var y = searchStart; y <= searchEnd; y++) {
-                var density = AverageDensity(rowDensities, y, 3);
+                var density = AverageDensity(rowDensities, y, CutDensityRadius);
                 var distancePenalty = Math.Abs(y - target) / ( double ) Math.Max(1, searchEnd - searchStart) * 0.01;
                 var score = density + distancePenalty;
                 if (score < bestScore) {

--- a/TelegramSearchBot/Service/AI/OCR/PaddleOCRService.cs
+++ b/TelegramSearchBot/Service/AI/OCR/PaddleOCRService.cs
@@ -43,9 +43,9 @@ namespace TelegramSearchBot.Service.AI.OCR {
                 return await ExecuteSliceAsync(image, slices[0]);
             }
 
-            var results = new List<string>(slices.Count);
+            var results = new List<(OcrImageSlice Slice, string Text)>(slices.Count);
             foreach (var slice in slices) {
-                results.Add(await ExecuteSliceAsync(image, slice));
+                results.Add((slice, await ExecuteSliceAsync(image, slice)));
             }
 
             return LongImageOcrSlicer.MergeResults(results);


### PR DESCRIPTION
## Summary
- carry slice overlap metadata into OCR result merging and deduplicate only real overlap boundaries
- judge safe cut points with the same seven-row density window used for cut selection
- add regressions for one-row false blanks, safe-cut repeated tokens, and overlap deduplication
- replace pixel-by-pixel test setup with Skia drawing to keep the expanded suite fast

## Accuracy evidence
A local ChineseV3 A/B probe used a generated 1000x7000 image with 116 labeled Chinese/English lines:

| Scenario | Whole image | Sliced | Avg. confidence |
| --- | ---: | ---: | ---: |
| Safe blank cuts | 76.70% | 99.95% | 70.51% -> 94.11% |
| Forced 96px overlap | 64.84% | 99.97% | 70.89% -> 93.84% |

The real-engine probe is not part of CI because the current Paddle inference runtime is Windows-specific and OCR output depends on native runtime/font rendering. The deterministic boundary behavior is covered by unit and service-level tests instead.

## Validation
- `dotnet test TelegramSearchBot.Test/TelegramSearchBot.Test.csproj --filter "FullyQualifiedName~LongImageOcrSlicerTests" --configuration Debug --no-restore`: 12/12 passed
- `dotnet build TelegramSearchBot.sln --configuration Release`: succeeded with 0 errors (434 existing warnings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OCR processing for long images by selecting safer slice boundaries based on surrounding image density.
  * Prevented duplicated text at overlapping slice boundaries while preserving repeated text when slices do not overlap.
  * Continued ignoring blank OCR results when combining output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->