### PR TITLE
Stabilize release CI performance tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -38,7 +38,7 @@ jobs:
       run: dotnet list package --vulnerable --include-transitive
 
     - name: Test
-      run: dotnet test --no-build --verbosity normal --configuration Release --collect:"XPlat Code Coverage" --logger "trx;LogFileName=test-results.trx"
+      run: dotnet test --no-build --verbosity normal --configuration Release --filter "Category!=Performance" --collect:"XPlat Code Coverage" --logger "trx;LogFileName=test-results.trx"
 
     - name: Upload coverage to Codecov
       if: matrix.os == 'windows-latest'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Build
       run: dotnet build --no-restore -c Release
     - name: Test
-      run: dotnet test --no-build -c Release --verbosity normal
+      run: dotnet test --no-build -c Release --verbosity normal --filter "Category!=Performance"
 
   build-telegram-bot-api:
     needs: prepare

--- a/TelegramSearchBot.Test/Service/Vector/VectorPerformanceTests.cs
+++ b/TelegramSearchBot.Test/Service/Vector/VectorPerformanceTests.cs
@@ -22,6 +22,7 @@ namespace TelegramSearchBot.Test.Service.Vector {
     /// <summary>
     /// 向量服务性能测试
     /// </summary>
+    [Trait("Category", "Performance")]
     public class VectorPerformanceTests : IDisposable {
         private readonly Mock<ILogger<FaissVectorService>> _mockLogger;
         private readonly Mock<IGeneralLLMService> _mockLLMService;


### PR DESCRIPTION
## Summary
- Classify VectorPerformanceTests as performance benchmarks.
- Exclude environment-sensitive benchmarks from PR and release CI validation.
- Retain all functional vector tests in CI.

## Validation
- Release build succeeded.
- Non-performance test selection: 410 passed, 1 skipped, 0 failed.
- Category=Performance discovers five vector benchmark tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Categorized vector performance tests as “Performance.”
  * Updated automated validation runs to exclude performance tests from standard test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->