### PR TITLE
Stabilize Garnet Lua integration timeout

### DIFF
--- a/TelegramSearchBot.Test/AppBootstrap/GarnetLuaScriptIntegrationTests.cs
+++ b/TelegramSearchBot.Test/AppBootstrap/GarnetLuaScriptIntegrationTests.cs
@@ -127,8 +127,8 @@ namespace TelegramSearchBot.Test.AppBootstrap {
                 AbortOnConnectFail = false,
                 ConnectRetry = 1,
                 ConnectTimeout = 500,
-                SyncTimeout = 2_000,
-                AsyncTimeout = 2_000
+                SyncTimeout = 15_000,
+                AsyncTimeout = 15_000
             };
             options.EndPoints.Add(IPAddress.Loopback, port);
 


### PR DESCRIPTION
## Summary
- increase the embedded Garnet integration test command timeout from 2 seconds to 15 seconds
- keep the test enabled in release validation
- leave production Redis settings unchanged

## Root cause
Release run 30183476870 reached the embedded Garnet server but a SETEX command took about 6.2 seconds on the hosted Windows runner and exceeded the test client 2-second timeout.

## Validation
- targeted Garnet Lua integration test passed
- Release solution build passed
- full Category!=Performance Release test selection passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased connection timeout thresholds for embedded service integration tests, improving reliability during slower startup or connection conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->