### PR TITLE
Bump ZstdSharp.Port from 0.8.5 to 0.8.7

### DIFF
--- a/TelegramSearchBot/TelegramSearchBot.csproj
+++ b/TelegramSearchBot/TelegramSearchBot.csproj
@@ -104,7 +104,7 @@
     <PackageReference Include="FaissNet" Version="1.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageReference Include="ScottPlot" Version="5.1.58" />
-    <PackageReference Include="ZstdSharp.Port" Version="0.8.5" />
+    <PackageReference Include="ZstdSharp.Port" Version="0.8.7" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\TelegramSearchBot.Common\TelegramSearchBot.Common.csproj" />


### PR DESCRIPTION
Replaces stale Dependabot PR #321, which became unmergeable after adjacent dependency updates landed.

Validation: Release solution build passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the compression component to a newer version for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->