### PR TITLE
Fix Sandboxie portable box startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@
   "SandboxieGroupFilesRoot": "",
   "SandboxieGlobalReadPaths": [],
   "SandboxieGlobalClosedPaths": [],
+  "SandboxieCommandTimeoutSeconds": 10,
+  "SandboxieToolHostStartupTimeoutSeconds": 15,
   "SandboxieToolTimeoutSeconds": 120,
   "OLTPAuth": "",
   "OLTPAuthUrl": "",
@@ -136,6 +138,8 @@
   - `SandboxieGroupFilesRoot`: 可选的额外每群文件根目录；为空时不开放。配置后，每个群只读开放 `<root>/<chatId>`。
   - 程序默认会关闭聊天资源父目录 `Photos`、`Audios`、`Videos`、`Files`，再仅为当前群的既有聊天媒体/文件目录生成只读授权：`Photos/<chatId>`、`Audios/<chatId>`、`Videos/<chatId>`、`Files/<chatId>`。其他群的资源目录默认不可读。Lucene `Index_Data` 不开放给 ToolHost；搜索仍由主进程侧服务完成。
   - `SandboxieGlobalReadPaths` / `SandboxieGlobalClosedPaths`: 额外全局只读开放/禁止访问路径。
+  - `SandboxieCommandTimeoutSeconds`: `SbieIni.exe` 和 `Start.exe /reload` 等 Sandboxie 配置命令的等待超时(默认10秒)。
+  - `SandboxieToolHostStartupTimeoutSeconds`: 启动 box 后等待 ToolHost 心跳的超时(默认15秒)。宿主负载较高时可适当增大。
   - `SandboxieToolTimeoutSeconds`: 沙箱工具调用等待超时(默认120秒)。
 
 启用 `EnableLLMAgentProcess=true` 后，主进程会负责任务排队、Telegram 发消息和流式转发；独立 Agent 进程负责执行 LLM 循环、本地工具和故障恢复。主进程会在 Agent 心跳超时、任务超时或配置切换时执行恢复、重试、死信投递和优雅停机。

--- a/README.md
+++ b/README.md
@@ -127,11 +127,12 @@
   - `AgentProcessMemoryLimitMb`: Agent 进程工作集上限(默认256MB)
   - `MaxToolCycles`: LLM工具调用最大迭代次数(默认25)，防止无限循环
   - `EnableLlmSandboxie`: 是否启用 Sandboxie Plus LLM 工具沙箱(默认false)。启用后 `ReadFile`/`WriteFile`/`EditFile`/`SearchText`/`ListFiles`/`ExecuteCommand` 会通过每群一个 Sandboxie portable box 的 ToolHost 执行。
-  - `SandboxieStartExe`: Sandboxie Plus `Start.exe` 路径。
-  - `SandboxieIniPath`: Sandboxie 主配置路径。仅在 `SandboxieAutoRegisterImportBox=true` 时用于自动加入 `ImportBox=<SandboxieBoxImportDirectory>\\*`。
-  - `SandboxieAutoRegisterImportBox`: 是否由程序自动把 portable box 目录注册到 Sandboxie 主配置(默认true)。如希望自行在 Sandboxie Plus 中添加便携容器目录，可设为 false。
+  - `SandboxieStartExe`: Sandboxie Plus `Start.exe` 路径。程序会使用同目录的 `SbieIni.exe` 注册 portable box 目录，并用 `Start.exe /reload` 重新加载配置和启动 ToolHost。
+  - `SandboxieIniPath`: Sandboxie 主配置路径。仅当 `SandboxieAutoRegisterImportBox=true` 且 `Start.exe` 同目录不存在 `SbieIni.exe` 时，作为直接写入 `ImportBox` 的回退路径。
+  - `SandboxieAutoRegisterImportBox`: 是否由程序自动把 portable box 目录注册到 Sandboxie 主配置(默认true)。程序先写 box INI，再注册目录、重载配置并启动 box；自动注册失败会立即报告具体错误。如希望自行在 Sandboxie Plus 中添加便携容器目录，可设为 false。
   - `SandboxieDenyHostFileSystem`: 是否默认关闭宿主机盘符根目录访问(默认false)。保持 false 时更适合运行 bash/npm/python 等工具链；写入仍由 Sandboxie 虚拟化，敏感项目数据仍会通过 `ClosedFilePath` 阻断。需要极严格白名单模式时可设为 true。
   - `SandboxieBoxImportDirectory`: portable box ini 目录；为空时默认 `%LOCALAPPDATA%/TelegramSearchBot/Sandboxie/Boxes`。每个群聊的 box ini 和虚拟文件根都生成在这里。
+  - `SandboxieBoxPrefix`: 每群 box 名称前缀。Sandboxie 名称只允许 1-38 个 ASCII 字母、数字和下划线；下划线是合法字符，程序会原样保留。前缀与 12 位稳定哈希拼接后的总长度不能超过 38。
   - `SandboxieGroupFilesRoot`: 可选的额外每群文件根目录；为空时不开放。配置后，每个群只读开放 `<root>/<chatId>`。
   - 程序默认会关闭聊天资源父目录 `Photos`、`Audios`、`Videos`、`Files`，再仅为当前群的既有聊天媒体/文件目录生成只读授权：`Photos/<chatId>`、`Audios/<chatId>`、`Videos/<chatId>`、`Files/<chatId>`。其他群的资源目录默认不可读。Lucene `Index_Data` 不开放给 ToolHost；搜索仍由主进程侧服务完成。
   - `SandboxieGlobalReadPaths` / `SandboxieGlobalClosedPaths`: 额外全局只读开放/禁止访问路径。

--- a/TelegramSearchBot.Common/Env.cs
+++ b/TelegramSearchBot.Common/Env.cs
@@ -79,6 +79,8 @@ namespace TelegramSearchBot.Common {
                 : config.SandboxieGroupFilesRoot.Trim();
             SandboxieGlobalReadPaths = config.SandboxieGlobalReadPaths ?? new List<string>();
             SandboxieGlobalClosedPaths = config.SandboxieGlobalClosedPaths ?? new List<string>();
+            SandboxieCommandTimeoutSeconds = Math.Clamp(config.SandboxieCommandTimeoutSeconds, 1, 3600);
+            SandboxieToolHostStartupTimeoutSeconds = Math.Clamp(config.SandboxieToolHostStartupTimeoutSeconds, 1, 3600);
             SandboxieToolTimeoutSeconds = Math.Clamp(config.SandboxieToolTimeoutSeconds, 5, 3600);
             EnableCodingAgentTool = config.EnableCodingAgentTool;
             CodingAgentAllowedGroupIds = config.CodingAgentAllowedGroupIds ?? new List<long>();
@@ -179,6 +181,8 @@ namespace TelegramSearchBot.Common {
         public static string SandboxieGroupFilesRoot { get; set; } = null!;
         public static List<string> SandboxieGlobalReadPaths { get; set; } = new List<string>();
         public static List<string> SandboxieGlobalClosedPaths { get; set; } = new List<string>();
+        public static int SandboxieCommandTimeoutSeconds { get; set; } = 10;
+        public static int SandboxieToolHostStartupTimeoutSeconds { get; set; } = 15;
         public static int SandboxieToolTimeoutSeconds { get; set; } = 120;
         public static bool EnableCodingAgentTool { get; set; } = false;
         public static List<long> CodingAgentAllowedGroupIds { get; set; } = new List<long>();
@@ -346,6 +350,8 @@ namespace TelegramSearchBot.Common {
         public string SandboxieGroupFilesRoot { get; set; } = string.Empty;
         public List<string> SandboxieGlobalReadPaths { get; set; } = new List<string>();
         public List<string> SandboxieGlobalClosedPaths { get; set; } = new List<string>();
+        public int SandboxieCommandTimeoutSeconds { get; set; } = 10;
+        public int SandboxieToolHostStartupTimeoutSeconds { get; set; } = 15;
         public int SandboxieToolTimeoutSeconds { get; set; } = 120;
         public bool EnableCodingAgentTool { get; set; } = false;
         public List<long> CodingAgentAllowedGroupIds { get; set; } = new List<long>();

--- a/TelegramSearchBot.LLMAgent/Service/SandboxToolConsumer.cs
+++ b/TelegramSearchBot.LLMAgent/Service/SandboxToolConsumer.cs
@@ -35,7 +35,7 @@ namespace TelegramSearchBot.LLMAgent.Service {
 
             _redis.ConnectionFailed += OnConnectionFailed;
             var watchdogTask = RunParentWatchdogAsync(parentProcessId, parentStartTicksUtc, linkedCts);
-            var heartbeatTask = RunHeartbeatAsync(chatId, boxName, linkedCts.Token);
+            var heartbeatTask = RunHeartbeatAsync(chatId, boxName, parentProcessId, linkedCts.Token);
             var db = _redis.GetDatabase();
             var queueKey = LlmAgentRedisKeys.SandboxToolQueue(chatId);
             _logger.LogInformation(
@@ -92,13 +92,19 @@ namespace TelegramSearchBot.LLMAgent.Service {
             }
         }
 
-        private async Task RunHeartbeatAsync(long chatId, string boxName, CancellationToken cancellationToken) {
+        private async Task RunHeartbeatAsync(long chatId, string boxName, int parentProcessId, CancellationToken cancellationToken) {
             var db = _redis.GetDatabase();
             var key = LlmAgentRedisKeys.SandboxToolHeartbeat(chatId);
             while (!cancellationToken.IsCancellationRequested) {
                 await db.StringSetAsync(
                     key,
-                    JsonConvert.SerializeObject(new { chatId, boxName, processId = Environment.ProcessId, updatedAtUtc = DateTime.UtcNow }),
+                    JsonConvert.SerializeObject(new {
+                        chatId,
+                        boxName,
+                        processId = Environment.ProcessId,
+                        parentProcessId,
+                        updatedAtUtc = DateTime.UtcNow
+                    }),
                     TimeSpan.FromSeconds(15));
                 await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken);
             }

--- a/TelegramSearchBot.Test/Service/AI/LLM/SandboxieToolHostServiceTests.cs
+++ b/TelegramSearchBot.Test/Service/AI/LLM/SandboxieToolHostServiceTests.cs
@@ -9,6 +9,29 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
     [Collection("AgentEnvSerial")]
     public class SandboxieToolHostServiceTests {
         [Fact]
+        public void BuildBoxName_PreservesUnderscores() {
+            var boxName = SandboxieToolHostService.BuildBoxName(12345L, "TGSB_G_");
+
+            Assert.StartsWith("TGSB_G_", boxName, StringComparison.Ordinal);
+            Assert.Equal(19, boxName.Length);
+        }
+
+        [Theory]
+        [InlineData("TGSB-G-")]
+        [InlineData("TGSB G ")]
+        [InlineData("沙箱_")]
+        public void BuildBoxName_RejectsInvalidPrefixes(string prefix) {
+            Assert.Throws<InvalidOperationException>(() => SandboxieToolHostService.BuildBoxName(12345L, prefix));
+        }
+
+        [Fact]
+        public void BuildBoxName_EnforcesSandboxieLengthLimit() {
+            Assert.Equal(38, SandboxieToolHostService.BuildBoxName(12345L, new string('A', 26)).Length);
+            Assert.Throws<InvalidOperationException>(() =>
+                SandboxieToolHostService.BuildBoxName(12345L, new string('A', 27)));
+        }
+
+        [Fact]
         public void BuildPortableBoxIni_AllowsOnlyCurrentChatResourceDirectories() {
             var originalGroupFilesRoot = Env.SandboxieGroupFilesRoot;
             var originalDenyHostFileSystem = Env.SandboxieDenyHostFileSystem;

--- a/TelegramSearchBot/Service/AI/LLM/SandboxieToolHostService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/SandboxieToolHostService.cs
@@ -26,9 +26,11 @@ namespace TelegramSearchBot.Service.AI.LLM {
             "ReadFile", "WriteFile", "EditFile", "SearchText", "ListFiles", "ExecuteCommand"
         };
 
+        private const int SandboxieCommandTimeoutMilliseconds = 10_000;
+        private const int ToolHostStartupTimeoutSeconds = 15;
+
         private readonly IConnectionMultiplexer _redis;
         private readonly ILogger<SandboxieToolHostService> _logger;
-        private readonly Dictionary<long, DateTime> _lastToolHostStarts = new();
         private readonly SemaphoreSlim _lock = new(1, 1);
 
         public SandboxieToolHostService(IConnectionMultiplexer redis, ILogger<SandboxieToolHostService> logger) {
@@ -116,20 +118,19 @@ namespace TelegramSearchBot.Service.AI.LLM {
             try {
                 var instance = BuildInstance(chatId);
                 EnsureBoxesDirectory(instance.BoxesDirectory);
+                EnsurePortableBoxDefinition(instance);
                 if (Env.SandboxieAutoRegisterImportBox) {
                     EnsureImportBoxDirective(instance.BoxesDirectory);
                 }
-                EnsurePortableBoxDefinition(instance);
 
-                if (await IsToolHostAliveAsync(chatId)) {
+                if (await IsToolHostAliveAsync(instance)) {
                     return instance;
                 }
 
-                if (_lastToolHostStarts.TryGetValue(chatId, out var lastStartedAt) && DateTime.UtcNow - lastStartedAt < TimeSpan.FromSeconds(10)) {
-                    return instance;
-                }
-
-                StartToolHost(instance);
+                ReloadSandboxieConfiguration();
+                EnsureSandboxieBoxLoaded(instance);
+                using var launcher = StartToolHost(instance);
+                await WaitForToolHostStartupAsync(instance, launcher, cancellationToken);
                 return instance;
             } finally {
                 _lock.Release();
@@ -137,13 +138,49 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         private void EnsureImportBoxDirective(string boxesDirectory) {
-            var iniPath = Env.SandboxieIniPath;
-            if (string.IsNullOrWhiteSpace(iniPath) || !File.Exists(iniPath)) {
-                _logger.LogWarning("Sandboxie.ini not found; portable boxes may not be imported automatically. Path={Path}", iniPath);
+            var importPath = $"{NormalizeSandboxiePath(boxesDirectory)}\\*";
+            var directive = $"ImportBox={importPath}";
+            var sbieIniExe = Path.Combine(Path.GetDirectoryName(Env.SandboxieStartExe) ?? string.Empty, "SbieIni.exe");
+
+            if (File.Exists(sbieIniExe)) {
+                var query = RunSandboxieCommand(
+                    sbieIniExe,
+                    new[] { "query", "GlobalSettings", "ImportBox" },
+                    SandboxieCommandTimeoutMilliseconds);
+                if (query.ExitCode == 0 && query.StandardOutput
+                        .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .Any(line => string.Equals(line, importPath, StringComparison.OrdinalIgnoreCase) ||
+                                     string.Equals(line, directive, StringComparison.OrdinalIgnoreCase))) {
+                    return;
+                }
+
+                var append = RunSandboxieCommand(
+                    sbieIniExe,
+                    new[] { "append", "/drv", "GlobalSettings", "ImportBox", importPath },
+                    SandboxieCommandTimeoutMilliseconds);
+                var verify = RunSandboxieCommand(
+                    sbieIniExe,
+                    new[] { "query", "GlobalSettings", "ImportBox" },
+                    SandboxieCommandTimeoutMilliseconds);
+                if (append.ExitCode != 0 || verify.ExitCode != 0 || !verify.StandardOutput
+                        .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                        .Any(line => string.Equals(line, importPath, StringComparison.OrdinalIgnoreCase) ||
+                                     string.Equals(line, directive, StringComparison.OrdinalIgnoreCase))) {
+                    throw new InvalidOperationException(
+                        $"Sandboxie failed to register the portable box directory. ExitCode={append.ExitCode}, Error={append.StandardError.Trim()}");
+                }
+
+                _logger.LogInformation("Registered Sandboxie ImportBox through SbieIni. Directive={Directive}", directive);
                 return;
             }
 
-            var directive = $"ImportBox={NormalizeSandboxiePath(boxesDirectory)}\\*";
+            var iniPath = Env.SandboxieIniPath;
+            if (string.IsNullOrWhiteSpace(iniPath) || !File.Exists(iniPath)) {
+                throw new FileNotFoundException(
+                    "Neither Sandboxie's SbieIni.exe nor the configured Sandboxie.ini was found; the portable box directory cannot be registered automatically.",
+                    iniPath);
+            }
+
             var text = File.ReadAllText(iniPath, Encoding.Unicode);
             if (text.IndexOf(directive, StringComparison.OrdinalIgnoreCase) >= 0) {
                 return;
@@ -167,12 +204,28 @@ namespace TelegramSearchBot.Service.AI.LLM {
                 File.WriteAllText(iniPath, text, Encoding.Unicode);
                 _logger.LogInformation("Added Sandboxie ImportBox directive. Ini={IniPath}, Directive={Directive}", iniPath, directive);
             } catch (Exception ex) {
-                _logger.LogWarning(ex, "Failed to add Sandboxie ImportBox directive. Run once with permissions or add it manually: {Directive}", directive);
+                throw new InvalidOperationException(
+                    $"Failed to register the portable box directory. Add '{directive}' under [GlobalSettings] or grant Sandboxie configuration access.",
+                    ex);
             }
         }
 
+        internal static string BuildBoxName(long chatId, string prefix) {
+            var boxName = prefix + ComputeStableHash(chatId.ToString());
+            if (boxName.Length is 0 or > 38 || boxName.Any(c =>
+                    !(c is >= 'A' and <= 'Z') &&
+                    !(c is >= 'a' and <= 'z') &&
+                    !(c is >= '0' and <= '9') &&
+                    c != '_')) {
+                throw new InvalidOperationException(
+                    $"Sandboxie box name '{boxName}' is invalid. Sandboxie allows 1-38 ASCII letters, digits, and underscores.");
+            }
+
+            return boxName;
+        }
+
         private static SandboxieInstance BuildInstance(long chatId) {
-            var boxName = Env.SandboxieBoxPrefix + ComputeStableHash(chatId.ToString());
+            var boxName = BuildBoxName(chatId, Env.SandboxieBoxPrefix);
             var boxesDir = Env.SandboxieBoxImportDirectory;
             return new SandboxieInstance(
                 chatId,
@@ -249,7 +302,42 @@ namespace TelegramSearchBot.Service.AI.LLM {
             return string.Join(Environment.NewLine, lines);
         }
 
-        private void StartToolHost(SandboxieInstance instance) {
+        private void ReloadSandboxieConfiguration() {
+            var startExe = Env.SandboxieStartExe;
+            if (!File.Exists(startExe)) {
+                throw new FileNotFoundException("Sandboxie Start.exe was not found. Configure SandboxieStartExe in Config.json.", startExe);
+            }
+
+            var result = RunSandboxieCommand(
+                startExe,
+                new[] { "/silent", "/reload" },
+                SandboxieCommandTimeoutMilliseconds);
+            if (result.ExitCode != 0) {
+                throw new InvalidOperationException(
+                    $"Sandboxie configuration reload failed. ExitCode={result.ExitCode}, Error={result.StandardError.Trim()}");
+            }
+        }
+
+        private void EnsureSandboxieBoxLoaded(SandboxieInstance instance) {
+            var sbieIniExe = Path.Combine(Path.GetDirectoryName(Env.SandboxieStartExe) ?? string.Empty, "SbieIni.exe");
+            if (!File.Exists(sbieIniExe)) {
+                return;
+            }
+
+            var result = RunSandboxieCommand(
+                sbieIniExe,
+                new[] { "query", "/boxes", "*" },
+                SandboxieCommandTimeoutMilliseconds);
+            var isLoaded = result.ExitCode == 0 && result.StandardOutput
+                .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Any(line => string.Equals(line, instance.BoxName, StringComparison.OrdinalIgnoreCase));
+            if (!isLoaded) {
+                throw new InvalidOperationException(
+                    $"Sandboxie did not load box '{instance.BoxName}' after configuration reload. Verify ImportBox, the INI filename/section name, and that the box is enabled.");
+            }
+        }
+
+        private Process StartToolHost(SandboxieInstance instance) {
             var startExe = Env.SandboxieStartExe;
             if (!File.Exists(startExe)) {
                 throw new FileNotFoundException("Sandboxie Start.exe was not found. Configure SandboxieStartExe in Config.json.", startExe);
@@ -265,6 +353,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
                 UseShellExecute = false,
                 CreateNoWindow = true
             };
+            psi.ArgumentList.Add("/silent");
             psi.ArgumentList.Add($"/box:{instance.BoxName}");
             psi.ArgumentList.Add(currentExe);
             var currentProcess = Process.GetCurrentProcess();
@@ -276,13 +365,89 @@ namespace TelegramSearchBot.Service.AI.LLM {
             psi.ArgumentList.Add(currentProcess.StartTime.ToUniversalTime().Ticks.ToString());
 
             var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start Sandboxie tool host process.");
-            _lastToolHostStarts[instance.ChatId] = DateTime.UtcNow;
             _logger.LogInformation("Started Sandboxie tool host launcher. ChatId={ChatId}, Box={BoxName}, LauncherPid={Pid}", instance.ChatId, instance.BoxName, process.Id);
+            return process;
         }
 
-        private async Task<bool> IsToolHostAliveAsync(long chatId) {
-            var value = await _redis.GetDatabase().StringGetAsync(LlmAgentRedisKeys.SandboxToolHeartbeat(chatId));
-            return value.HasValue && !string.IsNullOrWhiteSpace(value.ToString());
+        private async Task WaitForToolHostStartupAsync(SandboxieInstance instance, Process launcher, CancellationToken cancellationToken) {
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(ToolHostStartupTimeoutSeconds);
+            while (DateTime.UtcNow < deadline) {
+                if (await IsToolHostAliveAsync(instance)) {
+                    return;
+                }
+
+                if (launcher.HasExited && launcher.ExitCode != 0) {
+                    throw new InvalidOperationException(
+                        $"Sandboxie could not start box '{instance.BoxName}'. Start.exe exited with code {launcher.ExitCode}.");
+                }
+
+                await Task.Delay(200, cancellationToken);
+            }
+
+            if (!launcher.HasExited) {
+                try {
+                    launcher.Kill(entireProcessTree: true);
+                } catch {
+                }
+            }
+
+            throw new TimeoutException(
+                $"Sandboxie started box '{instance.BoxName}', but its tool host did not report a heartbeat within {ToolHostStartupTimeoutSeconds} seconds.");
+        }
+
+        private static (int ExitCode, string StandardOutput, string StandardError) RunSandboxieCommand(
+            string executable,
+            IEnumerable<string> arguments,
+            int timeoutMilliseconds) {
+            var startInfo = new ProcessStartInfo {
+                FileName = executable,
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                CreateNoWindow = true
+            };
+            foreach (var argument in arguments) {
+                startInfo.ArgumentList.Add(argument);
+            }
+
+            using var process = Process.Start(startInfo) ??
+                                throw new InvalidOperationException($"Failed to start Sandboxie command '{executable}'.");
+            var standardOutput = process.StandardOutput.ReadToEndAsync();
+            var standardError = process.StandardError.ReadToEndAsync();
+            if (!process.WaitForExit(timeoutMilliseconds)) {
+                try {
+                    process.Kill(entireProcessTree: true);
+                } catch {
+                }
+
+                throw new TimeoutException($"Sandboxie command '{Path.GetFileName(executable)}' timed out.");
+            }
+
+            return (
+                process.ExitCode,
+                standardOutput.GetAwaiter().GetResult(),
+                standardError.GetAwaiter().GetResult());
+        }
+
+        private async Task<bool> IsToolHostAliveAsync(SandboxieInstance instance) {
+            var value = await _redis.GetDatabase().StringGetAsync(LlmAgentRedisKeys.SandboxToolHeartbeat(instance.ChatId));
+            if (!value.HasValue || string.IsNullOrWhiteSpace(value.ToString())) {
+                return false;
+            }
+
+            try {
+                var heartbeat = JsonConvert.DeserializeObject<SandboxToolHeartbeatState>(value.ToString());
+                return heartbeat != null &&
+                       heartbeat.ParentProcessId == Environment.ProcessId &&
+                       string.Equals(heartbeat.BoxName, instance.BoxName, StringComparison.OrdinalIgnoreCase);
+            } catch (JsonException) {
+                return false;
+            }
+        }
+
+        private sealed class SandboxToolHeartbeatState {
+            public string BoxName { get; set; } = string.Empty;
+            public int ParentProcessId { get; set; }
         }
 
         private static string ComputeStableHash(string value) {

--- a/TelegramSearchBot/Service/AI/LLM/SandboxieToolHostService.cs
+++ b/TelegramSearchBot/Service/AI/LLM/SandboxieToolHostService.cs
@@ -26,9 +26,6 @@ namespace TelegramSearchBot.Service.AI.LLM {
             "ReadFile", "WriteFile", "EditFile", "SearchText", "ListFiles", "ExecuteCommand"
         };
 
-        private const int SandboxieCommandTimeoutMilliseconds = 10_000;
-        private const int ToolHostStartupTimeoutSeconds = 15;
-
         private readonly IConnectionMultiplexer _redis;
         private readonly ILogger<SandboxieToolHostService> _logger;
         private readonly SemaphoreSlim _lock = new(1, 1);
@@ -120,15 +117,15 @@ namespace TelegramSearchBot.Service.AI.LLM {
                 EnsureBoxesDirectory(instance.BoxesDirectory);
                 EnsurePortableBoxDefinition(instance);
                 if (Env.SandboxieAutoRegisterImportBox) {
-                    EnsureImportBoxDirective(instance.BoxesDirectory);
+                    await EnsureImportBoxDirectiveAsync(instance.BoxesDirectory, cancellationToken);
                 }
 
                 if (await IsToolHostAliveAsync(instance)) {
                     return instance;
                 }
 
-                ReloadSandboxieConfiguration();
-                EnsureSandboxieBoxLoaded(instance);
+                await ReloadSandboxieConfigurationAsync(cancellationToken);
+                await EnsureSandboxieBoxLoadedAsync(instance, cancellationToken);
                 using var launcher = StartToolHost(instance);
                 await WaitForToolHostStartupAsync(instance, launcher, cancellationToken);
                 return instance;
@@ -137,16 +134,17 @@ namespace TelegramSearchBot.Service.AI.LLM {
             }
         }
 
-        private void EnsureImportBoxDirective(string boxesDirectory) {
+        private async Task EnsureImportBoxDirectiveAsync(string boxesDirectory, CancellationToken cancellationToken) {
             var importPath = $"{NormalizeSandboxiePath(boxesDirectory)}\\*";
             var directive = $"ImportBox={importPath}";
             var sbieIniExe = Path.Combine(Path.GetDirectoryName(Env.SandboxieStartExe) ?? string.Empty, "SbieIni.exe");
 
             if (File.Exists(sbieIniExe)) {
-                var query = RunSandboxieCommand(
+                var query = await RunSandboxieCommandAsync(
                     sbieIniExe,
                     new[] { "query", "GlobalSettings", "ImportBox" },
-                    SandboxieCommandTimeoutMilliseconds);
+                    Env.SandboxieCommandTimeoutSeconds,
+                    cancellationToken);
                 if (query.ExitCode == 0 && query.StandardOutput
                         .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                         .Any(line => string.Equals(line, importPath, StringComparison.OrdinalIgnoreCase) ||
@@ -154,14 +152,16 @@ namespace TelegramSearchBot.Service.AI.LLM {
                     return;
                 }
 
-                var append = RunSandboxieCommand(
+                var append = await RunSandboxieCommandAsync(
                     sbieIniExe,
                     new[] { "append", "/drv", "GlobalSettings", "ImportBox", importPath },
-                    SandboxieCommandTimeoutMilliseconds);
-                var verify = RunSandboxieCommand(
+                    Env.SandboxieCommandTimeoutSeconds,
+                    cancellationToken);
+                var verify = await RunSandboxieCommandAsync(
                     sbieIniExe,
                     new[] { "query", "GlobalSettings", "ImportBox" },
-                    SandboxieCommandTimeoutMilliseconds);
+                    Env.SandboxieCommandTimeoutSeconds,
+                    cancellationToken);
                 if (append.ExitCode != 0 || verify.ExitCode != 0 || !verify.StandardOutput
                         .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                         .Any(line => string.Equals(line, importPath, StringComparison.OrdinalIgnoreCase) ||
@@ -181,7 +181,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
                     iniPath);
             }
 
-            var text = File.ReadAllText(iniPath, Encoding.Unicode);
+            var text = await File.ReadAllTextAsync(iniPath, Encoding.Unicode, cancellationToken);
             if (text.IndexOf(directive, StringComparison.OrdinalIgnoreCase) >= 0) {
                 return;
             }
@@ -201,8 +201,10 @@ namespace TelegramSearchBot.Service.AI.LLM {
                     }
                 }
 
-                File.WriteAllText(iniPath, text, Encoding.Unicode);
+                await File.WriteAllTextAsync(iniPath, text, Encoding.Unicode, cancellationToken);
                 _logger.LogInformation("Added Sandboxie ImportBox directive. Ini={IniPath}, Directive={Directive}", iniPath, directive);
+            } catch (OperationCanceledException) {
+                throw;
             } catch (Exception ex) {
                 throw new InvalidOperationException(
                     $"Failed to register the portable box directory. Add '{directive}' under [GlobalSettings] or grant Sandboxie configuration access.",
@@ -302,32 +304,34 @@ namespace TelegramSearchBot.Service.AI.LLM {
             return string.Join(Environment.NewLine, lines);
         }
 
-        private void ReloadSandboxieConfiguration() {
+        private async Task ReloadSandboxieConfigurationAsync(CancellationToken cancellationToken) {
             var startExe = Env.SandboxieStartExe;
             if (!File.Exists(startExe)) {
                 throw new FileNotFoundException("Sandboxie Start.exe was not found. Configure SandboxieStartExe in Config.json.", startExe);
             }
 
-            var result = RunSandboxieCommand(
+            var result = await RunSandboxieCommandAsync(
                 startExe,
                 new[] { "/silent", "/reload" },
-                SandboxieCommandTimeoutMilliseconds);
+                Env.SandboxieCommandTimeoutSeconds,
+                cancellationToken);
             if (result.ExitCode != 0) {
                 throw new InvalidOperationException(
                     $"Sandboxie configuration reload failed. ExitCode={result.ExitCode}, Error={result.StandardError.Trim()}");
             }
         }
 
-        private void EnsureSandboxieBoxLoaded(SandboxieInstance instance) {
+        private async Task EnsureSandboxieBoxLoadedAsync(SandboxieInstance instance, CancellationToken cancellationToken) {
             var sbieIniExe = Path.Combine(Path.GetDirectoryName(Env.SandboxieStartExe) ?? string.Empty, "SbieIni.exe");
             if (!File.Exists(sbieIniExe)) {
                 return;
             }
 
-            var result = RunSandboxieCommand(
+            var result = await RunSandboxieCommandAsync(
                 sbieIniExe,
                 new[] { "query", "/boxes", "*" },
-                SandboxieCommandTimeoutMilliseconds);
+                Env.SandboxieCommandTimeoutSeconds,
+                cancellationToken);
             var isLoaded = result.ExitCode == 0 && result.StandardOutput
                 .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Any(line => string.Equals(line, instance.BoxName, StringComparison.OrdinalIgnoreCase));
@@ -370,7 +374,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         private async Task WaitForToolHostStartupAsync(SandboxieInstance instance, Process launcher, CancellationToken cancellationToken) {
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(ToolHostStartupTimeoutSeconds);
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(Env.SandboxieToolHostStartupTimeoutSeconds);
             while (DateTime.UtcNow < deadline) {
                 if (await IsToolHostAliveAsync(instance)) {
                     return;
@@ -392,13 +396,14 @@ namespace TelegramSearchBot.Service.AI.LLM {
             }
 
             throw new TimeoutException(
-                $"Sandboxie started box '{instance.BoxName}', but its tool host did not report a heartbeat within {ToolHostStartupTimeoutSeconds} seconds.");
+                $"Sandboxie started box '{instance.BoxName}', but its tool host did not report a heartbeat within {Env.SandboxieToolHostStartupTimeoutSeconds} seconds.");
         }
 
-        private static (int ExitCode, string StandardOutput, string StandardError) RunSandboxieCommand(
+        private static async Task<(int ExitCode, string StandardOutput, string StandardError)> RunSandboxieCommandAsync(
             string executable,
             IEnumerable<string> arguments,
-            int timeoutMilliseconds) {
+            int timeoutSeconds,
+            CancellationToken cancellationToken) {
             var startInfo = new ProcessStartInfo {
                 FileName = executable,
                 UseShellExecute = false,
@@ -412,21 +417,31 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
             using var process = Process.Start(startInfo) ??
                                 throw new InvalidOperationException($"Failed to start Sandboxie command '{executable}'.");
-            var standardOutput = process.StandardOutput.ReadToEndAsync();
-            var standardError = process.StandardError.ReadToEndAsync();
-            if (!process.WaitForExit(timeoutMilliseconds)) {
+            var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
+            var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
+            using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            timeoutCts.CancelAfter(TimeSpan.FromSeconds(timeoutSeconds));
+            try {
+                await process.WaitForExitAsync(timeoutCts.Token);
+            } catch (OperationCanceledException) {
                 try {
                     process.Kill(entireProcessTree: true);
+                    await process.WaitForExitAsync(CancellationToken.None);
                 } catch {
                 }
 
-                throw new TimeoutException($"Sandboxie command '{Path.GetFileName(executable)}' timed out.");
+                if (cancellationToken.IsCancellationRequested) {
+                    throw;
+                }
+
+                throw new TimeoutException(
+                    $"Sandboxie command '{Path.GetFileName(executable)}' timed out after {timeoutSeconds} seconds.");
             }
 
             return (
                 process.ExitCode,
-                standardOutput.GetAwaiter().GetResult(),
-                standardError.GetAwaiter().GetResult());
+                await standardOutput,
+                await standardError);
         }
 
         private async Task<bool> IsToolHostAliveAsync(SandboxieInstance instance) {


### PR DESCRIPTION
## Summary
- create portable box INI before registering the ImportBox directory
- register through SbieIni /drv, reload Sandboxie, verify the box is loaded, then start and wait for the ToolHost heartbeat
- preserve and validate Sandboxie box names, including underscores, and reject stale heartbeats from prior parent processes

## Validation
- dotnet test TelegramSearchBot.Test/TelegramSearchBot.Test.csproj --filter FullyQualifiedName~SandboxieToolHostServiceTests --no-restore (10 passed)
- dotnet build TelegramSearchBot.sln --configuration Release --no-restore (0 errors; existing warnings remain)

## Environment limitation
- Sandboxie Plus is not installed on the development machine, so Start.exe/SbieIni.exe end-to-end execution could not be exercised locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved sandbox tool startup reliability with configuration reloads, registration verification, and clearer failure handling.
  * Added safeguards for valid sandbox names and matching process heartbeats.
  * Added command timeouts and cleanup for stalled sandbox operations.
  * Sandbox startup now supports silent execution and waits for confirmation that the expected sandbox is active.

* **Documentation**
  * Updated setup documentation with automatic registration, configuration discovery, reload behavior, and fallback guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->