### PR TITLE
feat: MiniMax 模型目录动态发现与 endpoint 规范化

### DIFF
--- a/Docs/Bot_Commands_User_Guide.md
+++ b/Docs/Bot_Commands_User_Guide.md
@@ -199,6 +199,7 @@
         *   **`刷新所有渠道` 指令的交互流程示例：**
             1.  管理员发送: `刷新所有渠道`
             2.  机器人回复: `已添加{n}个模型` (刷新并返回添加的模型数量)
+        *   **MiniMax 模型目录说明**: `MiniMax` 渠道使用 OpenAI-compatible `GET /v1/models` 动态发现账户可见模型；中国区网关为 `https://api.minimaxi.com`，国际区为 `https://api.minimax.io`，系统会自动补齐且不会重复追加 `/v1`。目录请求失败或返回空集合时，回退到官方文本模型快照 `MiniMax-M3`、`MiniMax-M2.7` / `MiniMax-M2.7-highspeed`、`MiniMax-M2.5` / `MiniMax-M2.5-highspeed`、`MiniMax-M2.1` / `MiniMax-M2.1-highspeed`、`MiniMax-M2`；刷新不会删除手工添加的旧版或账户专属模型 ID。官方依据（访问于 2026-08-14）：[中国区模型列表](https://platform.minimaxi.com/docs/api-reference/models/openai/list-models)、[国际区模型列表](https://platform.minimax.io/docs/api-reference/models/openai/list-models)、[中国区 OpenAI API](https://platform.minimaxi.com/docs/api-reference/text-openai-api)、[国际区 OpenAI API](https://platform.minimax.io/docs/api-reference/text-openai-api)。
         *   **`设置重试次数` 指令的交互流程示例：**
             1.  管理员发送: `设置重试次数`
             2.  机器人回复: `请输入最大重试次数(默认100):`

--- a/TelegramSearchBot.LLM.Test/Service/AI/LLM/LLMFactoryTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/AI/LLM/LLMFactoryTests.cs
@@ -91,6 +91,13 @@ namespace TelegramSearchBot.Test.Service.AI.LLM {
         }
 
         [Fact]
+        public void GetLLMService_MiniMax_ReturnsOpenAIService() {
+            var service = _factory.GetLLMService(LLMProvider.MiniMax);
+
+            Assert.Same(_openAIServiceMock.Object, service);
+        }
+
+        [Fact]
         public void GetLLMService_None_ThrowsKeyNotFound() {
             Assert.Throws<KeyNotFoundException>(() => _factory.GetLLMService(LLMProvider.None));
         }

--- a/TelegramSearchBot.LLM.Test/Service/AI/LLM/MiniMaxModelDiscoveryTests.cs
+++ b/TelegramSearchBot.LLM.Test/Service/AI/LLM/MiniMaxModelDiscoveryTests.cs
@@ -1,0 +1,110 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TelegramSearchBot.Interface;
+using TelegramSearchBot.Interface.AI.LLM;
+using TelegramSearchBot.Model.AI;
+using TelegramSearchBot.Model.Data;
+using TelegramSearchBot.Service.AI.LLM;
+using Xunit;
+
+namespace TelegramSearchBot.LLM.Test.Service.AI.LLM {
+    public class MiniMaxModelDiscoveryTests {
+        private static readonly string[] ExpectedFallbackModels = {
+            "MiniMax-M3",
+            "MiniMax-M2.7",
+            "MiniMax-M2.7-highspeed",
+            "MiniMax-M2.5",
+            "MiniMax-M2.5-highspeed",
+            "MiniMax-M2.1",
+            "MiniMax-M2.1-highspeed",
+            "MiniMax-M2"
+        };
+
+        [Theory]
+        [InlineData("https://api.minimaxi.com", "https://api.minimaxi.com/v1")]
+        [InlineData("https://api.minimaxi.com/", "https://api.minimaxi.com/v1")]
+        [InlineData("https://api.minimaxi.com/v1", "https://api.minimaxi.com/v1")]
+        [InlineData("https://api.minimaxi.com/v1/", "https://api.minimaxi.com/v1")]
+        [InlineData("https://api.minimax.io", "https://api.minimax.io/v1")]
+        [InlineData("https://api.minimax.io/v1/", "https://api.minimax.io/v1")]
+        public void NormalizeOpenAIEndpoint_MiniMax_AppendsV1ExactlyOnce(string gateway, string expected) {
+            var channel = new LLMChannel { Provider = LLMProvider.MiniMax, Gateway = gateway };
+
+            Assert.Equal(expected, OpenAIService.NormalizeOpenAIEndpoint(channel));
+        }
+
+        [Fact]
+        public void NormalizeOpenAIEndpoint_OtherProvider_PreservesGateway() {
+            var channel = new LLMChannel { Provider = LLMProvider.OpenAI, Gateway = "https://example.com/custom/" };
+
+            Assert.Equal("https://example.com/custom/", OpenAIService.NormalizeOpenAIEndpoint(channel));
+        }
+
+        [Fact]
+        public async Task GetAllModels_MiniMax_UsesDiscoveredAccountModels() {
+            var handler = new StubHandler(HttpStatusCode.OK, "{\"data\":[{\"id\":\"MiniMax-M3\"},{\"id\":\"account-only-model\"}]}");
+            var service = CreateService(handler);
+
+            var models = (await service.GetAllModels(CreateChannel("https://api.minimaxi.com"))).ToArray();
+
+            Assert.Equal(new[] { "MiniMax-M3", "account-only-model" }, models);
+            Assert.Equal("https://api.minimaxi.com/v1/models", handler.RequestUri?.AbsoluteUri);
+        }
+
+        [Theory]
+        [InlineData(HttpStatusCode.OK, "{\"data\":[]}")]
+        [InlineData(HttpStatusCode.BadGateway, "upstream unavailable")]
+        public async Task GetAllModels_MiniMax_UsesOfficialFallback_WhenDiscoveryUnavailable(HttpStatusCode statusCode, string content) {
+            var handler = new StubHandler(statusCode, content);
+            var service = CreateService(handler);
+
+            var models = (await service.GetAllModels(CreateChannel("https://api.minimaxi.com/v1"))).ToArray();
+
+            Assert.Equal(ExpectedFallbackModels, models);
+            Assert.Equal("https://api.minimaxi.com/v1/models", handler.RequestUri?.AbsoluteUri);
+        }
+
+        private static OpenAIService CreateService(StubHandler handler) {
+            var factory = new Mock<IHttpClientFactory>();
+            factory.Setup(x => x.CreateClient(It.IsAny<string>())).Returns(() => new HttpClient(handler, false));
+            return new OpenAIService(
+                null,
+                Mock.Of<ILogger<OpenAIService>>(),
+                Mock.Of<IMessageExtensionService>(),
+                factory.Object);
+        }
+
+        private static LLMChannel CreateChannel(string gateway) {
+            return new LLMChannel {
+                Provider = LLMProvider.MiniMax,
+                Gateway = gateway,
+                ApiKey = "test-key"
+            };
+        }
+
+        private sealed class StubHandler : HttpMessageHandler {
+            private readonly HttpStatusCode _statusCode;
+            private readonly string _content;
+
+            public StubHandler(HttpStatusCode statusCode, string content) {
+                _statusCode = statusCode;
+                _content = content;
+            }
+
+            public Uri? RequestUri { get; private set; }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+                RequestUri = request.RequestUri;
+                return Task.FromResult(new HttpResponseMessage(_statusCode) {
+                    Content = new StringContent(_content)
+                });
+            }
+        }
+    }
+}

--- a/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
+++ b/TelegramSearchBot.LLM/Service/AI/LLM/OpenAIService.cs
@@ -85,6 +85,19 @@ namespace TelegramSearchBot.Service.AI.LLM {
                    model.Contains("minimax", StringComparison.OrdinalIgnoreCase);
         }
 
+        internal static string NormalizeOpenAIEndpoint(LLMChannel channel) {
+            var gateway = channel?.Gateway ?? string.Empty;
+            if (channel?.Provider != LLMProvider.MiniMax) {
+                return gateway;
+            }
+
+            gateway = gateway.TrimEnd('/');
+            return !string.IsNullOrEmpty(gateway) &&
+                   !gateway.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)
+                ? $"{gateway}/v1"
+                : gateway;
+        }
+
         private static string SanitizeAndTruncateArguments(string arguments, int maxChars = 2048) {
             if (string.IsNullOrWhiteSpace(arguments)) {
                 return string.Empty;
@@ -242,9 +255,9 @@ namespace TelegramSearchBot.Service.AI.LLM {
                 return new List<string>();
             }
 
-            // MiniMax 使用预定义模型列表
             if (channel.Provider == LLMProvider.MiniMax) {
-                return _miniMaxModels;
+                var models = await GetGenericOpenAICompatibleModels(channel);
+                return models.Any() ? models : _miniMaxModels;
             }
 
             // 检查是否为OpenRouter
@@ -269,7 +282,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
                 // --- Client Setup ---
                 var clientOptions = new OpenAIClientOptions {
-                    Endpoint = new Uri(channel.Gateway),
+                    Endpoint = new Uri(NormalizeOpenAIEndpoint(channel)),
                     Transport = new HttpClientPipelineTransport(httpClient),
                 };
 
@@ -297,13 +310,13 @@ namespace TelegramSearchBot.Service.AI.LLM {
                 }
 
                 // 构建模型列表 URL，确保路径正确
-                var gatewayBase = channel.Gateway.TrimEnd('/');
+                var gatewayBase = NormalizeOpenAIEndpoint(channel);
                 var modelsUrl = gatewayBase.EndsWith("/v1", StringComparison.OrdinalIgnoreCase)
                     ? $"{gatewayBase}/models"
                     : $"{gatewayBase}/v1/models";
 
                 var response = await httpClient.GetAsync(modelsUrl);
-                if (!response.IsSuccessStatusCode) {
+                if (!response.IsSuccessStatusCode && channel.Provider != LLMProvider.MiniMax) {
                     // 尝试不带 /v1 的路径
                     var altUrl = $"{gatewayBase}/models";
                     if (altUrl != modelsUrl) {
@@ -348,16 +361,17 @@ namespace TelegramSearchBot.Service.AI.LLM {
         }
 
         /// <summary>
-        /// MiniMax预定义模型列表
+        /// MiniMax OpenAI-compatible text model fallback snapshot.
         /// </summary>
         private static readonly string[] _miniMaxModels = {
+            "MiniMax-M3",
+            "MiniMax-M2.7",
+            "MiniMax-M2.7-highspeed",
             "MiniMax-M2.5",
             "MiniMax-M2.5-highspeed",
             "MiniMax-M2.1",
             "MiniMax-M2.1-highspeed",
-            "MiniMax-M2",
-            "image-01",
-            "image-01-live"
+            "MiniMax-M2"
         };
 
         /// <summary>
@@ -404,7 +418,8 @@ namespace TelegramSearchBot.Service.AI.LLM {
             }
 
             if (channel.Provider == LLMProvider.MiniMax) {
-                return _miniMaxModels.Select(InferOpenAIModelCapabilities);
+                var models = await GetAllModels(channel);
+                return models.Select(InferOpenAIModelCapabilities);
             }
 
             // 检查是否为OpenRouter
@@ -439,7 +454,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
                 // 如果内部API失败，使用标准API并根据模型名称推断能力
                 var clientOptions = new OpenAIClientOptions {
-                    Endpoint = new Uri(channel.Gateway),
+                    Endpoint = new Uri(NormalizeOpenAIEndpoint(channel)),
                     Transport = new HttpClientPipelineTransport(httpClient),
                 };
 
@@ -1151,7 +1166,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
             using var client = _httpClientFactory.CreateClient();
             var clientOptions = new OpenAIClientOptions {
-                Endpoint = new Uri(channel.Gateway),
+                Endpoint = new Uri(NormalizeOpenAIEndpoint(channel)),
                 Transport = new HttpClientPipelineTransport(client),
             };
             var chatClient = new ChatClient(model: modelName, credential: new(channel.ApiKey), clientOptions);
@@ -1445,7 +1460,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
             using var client = _httpClientFactory.CreateClient();
             var clientOptions = new OpenAIClientOptions {
-                Endpoint = new Uri(channel.Gateway),
+                Endpoint = new Uri(NormalizeOpenAIEndpoint(channel)),
                 Transport = new HttpClientPipelineTransport(client),
             };
             var chatClient = new ChatClient(model: modelName, credential: new(channel.ApiKey), clientOptions);
@@ -1614,7 +1629,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
 
             using var client = _httpClientFactory.CreateClient();
             var clientOptions = new OpenAIClientOptions {
-                Endpoint = new Uri(channel.Gateway),
+                Endpoint = new Uri(NormalizeOpenAIEndpoint(channel)),
                 Transport = new HttpClientPipelineTransport(client),
             };
             var chatClient = new ChatClient(model: modelName, credential: new(channel.ApiKey), clientOptions);
@@ -1915,7 +1930,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             using var httpClient = _httpClientFactory.CreateClient();
 
             var clientOptions = new OpenAIClientOptions {
-                Endpoint = new Uri(channel.Gateway),
+                Endpoint = new Uri(NormalizeOpenAIEndpoint(channel)),
                 Transport = new HttpClientPipelineTransport(httpClient),
             };
 
@@ -2022,7 +2037,7 @@ namespace TelegramSearchBot.Service.AI.LLM {
             using var httpClient = _httpClientFactory.CreateClient();
 
             var clientOptions = new OpenAIClientOptions {
-                Endpoint = new Uri(channel.Gateway),
+                Endpoint = new Uri(NormalizeOpenAIEndpoint(channel)),
                 Transport = new HttpClientPipelineTransport(httpClient),
             };
 

--- a/TelegramSearchBot.Test/Manage/EditLLMConfHelperTest.cs
+++ b/TelegramSearchBot.Test/Manage/EditLLMConfHelperTest.cs
@@ -79,6 +79,7 @@ namespace TelegramSearchBot.Test.Manage {
             // 新增 ILLMFactory mock
             var llmFactoryMock = new Mock<ILLMFactory>();
             llmFactoryMock.Setup(f => f.GetLLMService(LLMProvider.OpenAI)).Returns(_openAIServiceMock.Object);
+            llmFactoryMock.Setup(f => f.GetLLMService(LLMProvider.MiniMax)).Returns(_openAIServiceMock.Object);
             llmFactoryMock.Setup(f => f.GetLLMService(LLMProvider.Ollama)).Returns(_ollamaServiceMock.Object);
             llmFactoryMock.Setup(f => f.GetLLMService(LLMProvider.Gemini)).Returns(_geminiServiceMock.Object);
 
@@ -158,6 +159,26 @@ namespace TelegramSearchBot.Test.Manage {
 
             // count reflects restored + added
             Assert.Equal(2, count);  // 1 restored + 1 added
+        }
+
+        [Fact]
+        public async Task RefreshAllChannel_MiniMax_ShouldPreserveMissingManualModel() {
+            var channel = new LLMChannel { Id = 14, Name = "MiniMax", Provider = LLMProvider.MiniMax };
+            await _context.LLMChannels.AddAsync(channel);
+            await _context.ChannelsWithModel.AddAsync(new ChannelWithModel {
+                LLMChannelId = 14,
+                ModelName = "legacy-or-account-specific-model",
+                IsDeleted = false
+            });
+            await _context.SaveChangesAsync();
+
+            await _helper.RefreshAllChannel();
+
+            var manualModel = await _context.ChannelsWithModel
+                .FirstAsync(m => m.LLMChannelId == 14 && m.ModelName == "legacy-or-account-specific-model");
+            Assert.False(manualModel.IsDeleted);
+            Assert.Contains(await _context.ChannelsWithModel.Where(m => m.LLMChannelId == 14).ToListAsync(),
+                m => m.ModelName == "openai-model1" && !m.IsDeleted);
         }
 
         [Fact]

--- a/TelegramSearchBot/Service/Manage/EditLLMConfHelper.cs
+++ b/TelegramSearchBot/Service/Manage/EditLLMConfHelper.cs
@@ -133,9 +133,11 @@ namespace TelegramSearchBot.Service.Manage {
                         .Where(x => !x.IsDeleted)
                         .Select(x => x.ModelName)
                         .ToHashSet();
-                    var toDelete = existingRecords
-                        .Where(x => !x.IsDeleted && !modelSet.Contains(x.ModelName))
-                        .ToList();
+                    var toDelete = channel.Provider == LLMProvider.MiniMax
+                        ? new List<ChannelWithModel>()
+                        : existingRecords
+                            .Where(x => !x.IsDeleted && !modelSet.Contains(x.ModelName))
+                            .ToList();
                     foreach (var record in toDelete) {
                         record.IsDeleted = true;
                         _logger.LogInformation("通道 {ChannelName} 标记删除消失的模型 {ModelName}", channel.Name, record.ModelName);


### PR DESCRIPTION
## 变更内容

MiniMax 模型目录更新：

1. **Endpoint /v1 规范化**：MiniMax 双区（国内/国际）endpoint 统一规范化为 /v1 路径。
2. **动态模型目录**：启动时动态拉取 MiniMax 模型列表；当返回空集合或 BadGateway 时，回退到 8 个官方模型 ID（MiniMax-M3, M2.7/-highspeed, M2.5/-highspeed, M2.1/-highspeed, M2），保证模型目录始终可用。
3. **软删保护**：RefreshAllChannel 仅在 Provider == MiniMax 时跳过缺失模型的软删除，避免误删其他 Provider 的模型。

## 测试

- `dotnet test TelegramSearchBot.LLM.Test --filter "FullyQualifiedName~MiniMax"`：14/14 通过
- `dotnet test TelegramSearchBot.Test --filter "FullyQualifiedName~EditLLMConf"`：22/22 通过
- Release build 0 errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MiniMax now discovers available models through OpenAI-compatible model endpoints.
  * Supports both China and international gateways with automatic endpoint normalization.
  * Preserves manually added models during channel refreshes.
  * Uses an official fallback model list when discovery fails or returns no results.
  * Expanded MiniMax text model coverage and removed image models from the fallback list.

* **Bug Fixes**
  * Improved MiniMax model and capability detection across supported operations.
  * Prevented missing MiniMax models from being incorrectly marked as deleted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->